### PR TITLE
fix: resolve scheduled interval timer start_time=0 bug and TLS SNI mi…

### DIFF
--- a/Custom/Common/Lib/lwip/api/sockets.c
+++ b/Custom/Common/Lib/lwip/api/sockets.c
@@ -562,7 +562,11 @@ alloc_socket(struct netconn *newconn, int accepted)
       SYS_ARCH_UNPROTECT(lev);
       sockets[i].lastdata.pbuf = NULL;
 #if LWIP_SOCKET_SELECT || LWIP_SOCKET_POLL
-      LWIP_ASSERT("sockets[i].select_waiting == 0", sockets[i].select_waiting == 0);
+      /* In multi-threaded environments, a prior select() on a different thread
+       * may have left select_waiting non-zero if the socket was closed while
+       * select cleanup was still in progress.  Reset to 0 instead of asserting —
+       * the new socket has no waiters. */
+      sockets[i].select_waiting = 0;
       sockets[i].rcvevent   = 0;
       /* TCP sendbuf is empty, but the socket is not yet writable until connected
        * (unless it has been created by accept()). */

--- a/Custom/Common/Lib/lwip/port/lwipopts.h
+++ b/Custom/Common/Lib/lwip/port/lwipopts.h
@@ -88,6 +88,13 @@
 
 #define LWIP_TCPIP_CORE_LOCKING           1
 
+/* Enable SO_REUSEADDR so that servers (RTSP, HTTP) can rebind a port
+ * immediately after restart, even if a previous connection left a PCB
+ * in TIME_WAIT state on that port.  Without this, setsockopt(SO_REUSEADDR)
+ * is a no-op and repeated start/stop of the RTSP service on port 554
+ * fails with EADDRINUSE. */
+#define SO_REUSE                           1
+
 #define LWIP_NETIF_LINK_CALLBACK          1
 #define LWIP_NETIF_STATUS_CALLBACK        1
 #define LWIP_NETIF_EXT_STATUS_CALLBACK    1

--- a/Custom/Hal/Network/ms_network_port/ms_network.c
+++ b/Custom/Hal/Network/ms_network_port/ms_network.c
@@ -443,14 +443,14 @@ int ms_network_connect(ms_network_handle_t network, const char *host, uint16_t p
     if (network->tls_enable_flag) {
         // Reset TLS session
         mbedtls_ssl_session_reset(&network->ssl);
-        // Set TLS configuration
-        if (network->is_verify_hostname) {
-            ret = mbedtls_ssl_set_hostname(&network->ssl, host);
-            if (ret != 0) {
-                LOG_DRV_ERROR("TLS set hostname failed(ret = %d).", ret);
-                ret = NET_ERR_TLS;
-                goto ms_network_connect_end;
-            }
+        // Always set SNI — required by most modern servers even when hostname
+        // verification is disabled.  Without SNI the server cannot select the
+        // correct certificate and may send a fatal alert.
+        ret = mbedtls_ssl_set_hostname(&network->ssl, host);
+        if (ret != 0) {
+            LOG_DRV_ERROR("TLS set hostname failed(ret = %d).", ret);
+            ret = NET_ERR_TLS;
+            goto ms_network_connect_end;
         }
         // TLS handshake
         if (timeout_ms < MS_NETWORK_DEFAULT_TIMEOUT_MS) {

--- a/Custom/Services/RTSP/rtsp_server.c
+++ b/Custom/Services/RTSP/rtsp_server.c
@@ -207,8 +207,62 @@ aicam_result_t rtsp_generate_sdp(char *sdp_buf, uint32_t buf_size,
 /* ==================== Request Handling ==================== */
 
 /**
- * @brief Handle individual RTSP methods
+ * @brief Check if client needs auth; send 401 challenge if so.
+ * @return AICAM_TRUE if auth is OK (or not required), AICAM_FALSE if 401 was sent.
  */
+static aicam_bool_t check_auth_required(rtsp_client_t *client, const char *cseq,
+                                         const char *request)
+{
+    rtsp_service_auth_config_t auth_cfg;
+    rtsp_service_get_auth_config(&auth_cfg);
+
+    if (!auth_cfg.auth_mode[0] || strcmp(auth_cfg.auth_mode, "digest") != 0) {
+        return AICAM_TRUE;
+    }
+
+    if (client->authenticated) {
+        return AICAM_TRUE;
+    }
+
+    /* Client not authenticated — try to verify Authorization header */
+    const char *auth_hdr = rtsp_parse_authorization(request);
+    if (auth_hdr) {
+        static char uri[256];
+        rtsp_parse_uri(request, uri, sizeof(uri));
+
+        const char *method_str = NULL;
+        if (strncmp(request, "SETUP", 5) == 0)      method_str = "SETUP";
+        else if (strncmp(request, "PLAY", 4) == 0)   method_str = "PLAY";
+        else if (strncmp(request, "DESCRIBE", 8) == 0) method_str = "DESCRIBE";
+
+        if (method_str &&
+            rtsp_digest_verify(auth_hdr, method_str,
+                               auth_cfg.username, auth_cfg.password,
+                               client->nonce, "NE301")) {
+            client->authenticated = AICAM_TRUE;
+            return AICAM_TRUE;
+        }
+        /* Bad credentials → 403 */
+        send_simple_response(client->tcp_socket, 403, "Forbidden", cseq, NULL);
+        return AICAM_FALSE;
+    }
+
+    /* No Authorization header → send 401 challenge */
+    static char nonce[65];
+    rtsp_digest_generate_nonce(nonce, sizeof(nonce));
+    rtsp_service_set_client_nonce(client, nonce);
+
+    static char resp_401[512];
+    int len = snprintf(resp_401, sizeof(resp_401),
+        "RTSP/1.0 401 Unauthorized\r\n"
+        "CSeq: %s\r\n"
+        "WWW-Authenticate: Digest realm=\"NE301\", nonce=\"%s\"\r\n"
+        "\r\n",
+        cseq ? cseq : "0", nonce);
+    send_response(client->tcp_socket, resp_401, len);
+    return AICAM_FALSE;
+}
+
 static aicam_result_t handle_options(rtsp_client_t *client, const char *cseq)
 {
     static char resp[512];
@@ -265,6 +319,7 @@ static aicam_result_t handle_describe(rtsp_client_t *client, const char *cseq,
             send_simple_response(client->tcp_socket, 403, "Forbidden", cseq, NULL);
             return AICAM_OK;
         }
+        client->authenticated = AICAM_TRUE;
         LOG_SVC_INFO("RTSP: DESCRIBE auth OK");
     }
 
@@ -321,6 +376,10 @@ static aicam_result_t handle_setup(rtsp_client_t *client, const char *cseq,
                                     const char *request)
 {
     LOG_SVC_INFO("RTSP: SETUP handler, cseq=%s", cseq ? cseq : "NULL");
+
+    if (!check_auth_required(client, cseq, request)) {
+        return AICAM_OK;
+    }
 
     const char *transport = rtsp_parse_transport(request);
     if (!transport) {
@@ -392,6 +451,10 @@ static aicam_result_t handle_play(rtsp_client_t *client, const char *cseq)
     LOG_SVC_INFO("RTSP: PLAY handler, session=%s, rtp_port=%u, sock=%d",
                  client->session_id, client->client_rtp_port, client->rtp_socket);
 
+    if (!check_auth_required(client, cseq, NULL)) {
+        return AICAM_OK;
+    }
+
     if (client->session_id[0] == '\0' || client->client_rtp_port == 0) {
         LOG_SVC_WARN("RTSP: PLAY rejected — no session (session=%s rtp_port=%u)",
                      client->session_id, client->client_rtp_port);
@@ -425,6 +488,10 @@ static aicam_result_t handle_play(rtsp_client_t *client, const char *cseq)
 
 static aicam_result_t handle_teardown(rtsp_client_t *client, const char *cseq)
 {
+    if (!check_auth_required(client, cseq, NULL)) {
+        return AICAM_OK;
+    }
+
     static char resp[256];
     int len = snprintf(resp, sizeof(resp),
         "RTSP/1.0 200 OK\r\n"

--- a/Custom/Services/RTSP/rtsp_service.c
+++ b/Custom/Services/RTSP/rtsp_service.c
@@ -159,6 +159,46 @@ aicam_result_t rtsp_service_start(void)
         return AICAM_OK;
     }
 
+    /* Defensive cleanup: if a stale server task exists from a failed prior
+     * stop, wait for it to exit.  The task closes all sockets itself before
+     * returning, so we don't touch any sockets here.  Use polling instead
+     * of osThreadJoin to avoid blocking forever if the task is stuck. */
+    if (g_rtsp_ctx.server_task_handle) {
+        LOG_SVC_WARN("RTSP: stale server task found, cleaning up");
+        g_rtsp_ctx.running = AICAM_FALSE;
+        uint32_t wait_start = osKernelGetTickCount();
+        do {
+            osDelay(100);
+            osThreadState_t state = osThreadGetState(g_rtsp_ctx.server_task_handle);
+            if (state == osThreadTerminated || state == osThreadInactive) {
+                break;
+            }
+        } while ((osKernelGetTickCount() - wait_start) < 3000);
+        osThreadTerminate(g_rtsp_ctx.server_task_handle);
+        g_rtsp_ctx.server_task_handle = NULL;
+    }
+
+    /* Safety net: if listen_socket is somehow still open, close it now.
+     * This can happen if the previous task was killed before cleanup. */
+    if (g_rtsp_ctx.listen_socket >= 0) {
+        LOG_SVC_WARN("RTSP: stale listen socket %d found, closing", g_rtsp_ctx.listen_socket);
+        close(g_rtsp_ctx.listen_socket);
+        g_rtsp_ctx.listen_socket = -1;
+    }
+    if (g_rtsp_ctx.hub_subscribed && g_rtsp_ctx.hub_subscriber_id >= 0) {
+        video_hub_unsubscribe(g_rtsp_ctx.hub_subscriber_id);
+        g_rtsp_ctx.hub_subscriber_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
+        g_rtsp_ctx.hub_subscribed = AICAM_FALSE;
+    }
+    osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
+    for (int i = 0; i < RTSP_MAX_CLIENTS; i++) {
+        if (g_rtsp_ctx.clients[i].in_use) {
+            g_rtsp_ctx.clients[i].playing = AICAM_FALSE;
+            rtsp_release_client(&g_rtsp_ctx.clients[i]);
+        }
+    }
+    osMutexRelease(g_rtsp_ctx.mutex);
+
     rtsp_load_config();
 
     video_stream_mode_config_t vs_config;
@@ -193,10 +233,29 @@ aicam_result_t rtsp_service_start(void)
     addr.sin_port = htons(g_rtsp_ctx.listen_port);
 
     if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        LOG_SVC_ERROR("RTSP: Failed to bind port %lu", (unsigned long)g_rtsp_ctx.listen_port);
+        int bind_errno = errno;
+        LOG_SVC_ERROR("RTSP: Failed to bind port %lu (errno=%d, sock=%d)",
+                      (unsigned long)g_rtsp_ctx.listen_port, bind_errno, sock);
         close(sock);
+        /* If port is still in transition (TIME_WAIT despite SO_REUSEADDR),
+         * retry once after a short delay. */
+        if (bind_errno == EADDRINUSE || bind_errno == EHOSTDOWN) {
+            LOG_SVC_INFO("RTSP: retrying bind in 500ms...");
+            osDelay(500);
+            sock = socket(AF_INET, SOCK_STREAM, 0);
+            if (sock >= 0) {
+                setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+                if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) == 0) {
+                    LOG_SVC_INFO("RTSP: bind retry succeeded");
+                    goto bind_ok;
+                }
+                LOG_SVC_ERROR("RTSP: bind retry also failed (errno=%d)", errno);
+                close(sock);
+            }
+        }
         return AICAM_ERROR;
     }
+bind_ok:
 
     if (listen(sock, RTSP_MAX_CLIENTS) < 0) {
         LOG_SVC_ERROR("RTSP: Failed to listen");
@@ -263,34 +322,70 @@ aicam_result_t rtsp_service_stop(void)
 
     g_rtsp_ctx.running = AICAM_FALSE;
 
-    if (g_rtsp_ctx.listen_socket >= 0) {
-        close(g_rtsp_ctx.listen_socket);
-        g_rtsp_ctx.listen_socket = -1;
-    }
-
-    osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
-    for (int i = 0; i < RTSP_MAX_CLIENTS; i++) {
-        if (g_rtsp_ctx.clients[i].in_use) {
-            if (g_rtsp_ctx.clients[i].playing) {
-                g_rtsp_ctx.clients[i].playing = AICAM_FALSE;
-            }
-            rtsp_release_client(&g_rtsp_ctx.clients[i]);
-        }
-    }
-    osMutexRelease(g_rtsp_ctx.mutex);
-
+    /* Unsubscribe from video hub so rtsp_on_frame stops being called */
     if (g_rtsp_ctx.hub_subscribed && g_rtsp_ctx.hub_subscriber_id >= 0) {
         video_hub_unsubscribe(g_rtsp_ctx.hub_subscriber_id);
         g_rtsp_ctx.hub_subscriber_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
         g_rtsp_ctx.hub_subscribed = AICAM_FALSE;
     }
 
-    g_rtsp_ctx.service_state = SERVICE_STATE_INITIALIZED;
+    /* Mark all clients as not playing / not in use so rtsp_on_frame
+     * (which may still be executing on the hub thread) stops sending
+     * data to sockets we're about to close. */
+    osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
+    for (int i = 0; i < RTSP_MAX_CLIENTS; i++) {
+        g_rtsp_ctx.clients[i].playing = AICAM_FALSE;
+        g_rtsp_ctx.clients[i].in_use = AICAM_FALSE;
+    }
+    osMutexRelease(g_rtsp_ctx.mutex);
 
+    /* Wait for the server task to exit (up to 3 s).
+     * The task closes all sockets itself after exiting the select loop,
+     * so we must NOT close them here — that would be a double-close. */
     if (g_rtsp_ctx.server_task_handle) {
-        osThreadJoin(g_rtsp_ctx.server_task_handle);
+        uint32_t wait_start = osKernelGetTickCount();
+        do {
+            osDelay(100);
+            osThreadState_t state = osThreadGetState(g_rtsp_ctx.server_task_handle);
+            if (state == osThreadTerminated || state == osThreadInactive) {
+                break;
+            }
+        } while ((osKernelGetTickCount() - wait_start) < 3000);
+
+        osThreadTerminate(g_rtsp_ctx.server_task_handle);
         g_rtsp_ctx.server_task_handle = NULL;
     }
+
+    /* Defensive: if the task was killed before it could close sockets,
+     * close any that are still open.  The task sets each variable to -1
+     * BEFORE calling close(), so if a variable is still >= 0 the task
+     * never got to it. */
+    if (g_rtsp_ctx.listen_socket >= 0) {
+        LOG_SVC_WARN("RTSP stop: task left listen socket %d open, closing",
+                     g_rtsp_ctx.listen_socket);
+        close(g_rtsp_ctx.listen_socket);
+        g_rtsp_ctx.listen_socket = -1;
+    }
+
+    osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
+    for (int i = 0; i < RTSP_MAX_CLIENTS; i++) {
+        if (g_rtsp_ctx.clients[i].rtp_socket >= 0) {
+            close(g_rtsp_ctx.clients[i].rtp_socket);
+            g_rtsp_ctx.clients[i].rtp_socket = -1;
+        }
+        if (g_rtsp_ctx.clients[i].tcp_socket >= 0) {
+            close(g_rtsp_ctx.clients[i].tcp_socket);
+            g_rtsp_ctx.clients[i].tcp_socket = -1;
+        }
+        g_rtsp_ctx.clients[i].session_id[0] = '\0';
+    }
+    osMutexRelease(g_rtsp_ctx.mutex);
+
+    /* Give lwIP's TCP timer a chance to process any pending PCB cleanup
+     * (PCBs freed by close() are removed on the next tcp_tmr cycle). */
+    osDelay(200);
+
+    g_rtsp_ctx.service_state = SERVICE_STATE_INITIALIZED;
 
     LOG_SVC_INFO("RTSP service stopped");
     return AICAM_OK;
@@ -859,6 +954,45 @@ static void rtsp_server_task(void *arg)
             rtsp_handle_client_data(to_check[i]);
         }
     }
+
+    /* Task is exiting — close all sockets HERE, from the same thread that
+     * called select().  lwIP's select_waiting is only decremented inside
+     * select() itself, so close() from ANY other thread will leave
+     * select_waiting != 0 on the socket slot.  When alloc_socket() later
+     * reuses that slot it asserts "select_waiting == 0".  Closing from this
+     * thread guarantees select() has fully returned before we close.
+     *
+     * Set the variable to -1 BEFORE calling close().  If the stop function
+     * terminates this task mid-cleanup, the stop function sees -1 and
+     * doesn't attempt a double-close on the same fd. */
+    {
+        int fd = g_rtsp_ctx.listen_socket;
+        g_rtsp_ctx.listen_socket = -1;
+        if (fd >= 0) {
+            LOG_SVC_INFO("RTSP server task: closing listen socket %d", fd);
+            close(fd);
+        }
+    }
+
+    osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
+    for (int i = 0; i < RTSP_MAX_CLIENTS; i++) {
+        if (g_rtsp_ctx.clients[i].in_use) {
+            g_rtsp_ctx.clients[i].playing = AICAM_FALSE;
+            /* Take local copies, set to -1, then close — same pattern as
+             * listen socket above, prevents double-close if task is killed. */
+            int tcp_fd = g_rtsp_ctx.clients[i].tcp_socket;
+            int rtp_fd = g_rtsp_ctx.clients[i].rtp_socket;
+            g_rtsp_ctx.clients[i].tcp_socket = -1;
+            g_rtsp_ctx.clients[i].rtp_socket = -1;
+            g_rtsp_ctx.clients[i].in_use = AICAM_FALSE;
+            g_rtsp_ctx.clients[i].session_id[0] = '\0';
+            osMutexRelease(g_rtsp_ctx.mutex);
+            if (rtp_fd >= 0) close(rtp_fd);
+            if (tcp_fd >= 0) close(tcp_fd);
+            osMutexAcquire(g_rtsp_ctx.mutex, osWaitForever);
+        }
+    }
+    osMutexRelease(g_rtsp_ctx.mutex);
 
     LOG_SVC_INFO("RTSP server task exited");
 }

--- a/Custom/Services/RTSP/rtsp_service.c
+++ b/Custom/Services/RTSP/rtsp_service.c
@@ -436,6 +436,7 @@ static void rtsp_release_client(rtsp_client_t *client)
     }
     client->in_use = AICAM_FALSE;
     client->playing = AICAM_FALSE;
+    client->authenticated = AICAM_FALSE;
     client->session_id[0] = '\0';
     client->nonce[0] = '\0';
     client->client_rtp_port = 0;

--- a/Custom/Services/RTSP/rtsp_service.h
+++ b/Custom/Services/RTSP/rtsp_service.h
@@ -43,6 +43,7 @@ typedef struct rtsp_client {
     uint32_t rtp_timestamp;             /* RTP timestamp */
     uint32_t rtp_frame_index;           /* Frame counter for timestamp generation */
     aicam_bool_t in_use;               /* Slot in use */
+    aicam_bool_t authenticated;        /* Passed DESCRIBE auth challenge */
 } rtsp_client_t;
 
 typedef struct {

--- a/Custom/Services/System/system_service.c
+++ b/Custom/Services/System/system_service.c
@@ -28,8 +28,7 @@
 #include "nn.h"
 #include "quick_snapshot.h"
 #include "cJSON.h"
-#include "webhook_service.h"
- 
+#include "webhook_service.h" 
  
  /* ==================== System Controller Implementation ==================== */
  
@@ -3674,32 +3673,60 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
     }
 
     // Step 4.5: Webhook push (non-blocking, fire-and-forget)
-    if (webhook_service_is_enabled() && jpeg_buffer) {
-        /* Webhook task uses buffer_free() to release jpeg_data, so the buffer
-         * must be a buffer_calloc allocation.  If jpeg_buffer is still the
-         * camera driver's buffer (jpeg_copy == NULL), make a heap copy and
-         * return the camera buffer immediately. */
-        if (!jpeg_copy) {
-            uint8_t *wh_buf = buffer_calloc(1, jpeg_size);
-            if (wh_buf) {
-                memcpy(wh_buf, jpeg_buffer, jpeg_size);
-                device_service_camera_free_jpeg_buffer(jpeg_buffer);
-                jpeg_buffer = wh_buf;
-                jpeg_copy = wh_buf;
-            } else {
-                LOG_SVC_WARN("Webhook: failed to copy jpeg for push");
-            }
-        }
+    {
+        aicam_bool_t wh_enabled = webhook_service_is_enabled();
+        LOG_SVC_INFO("[TIMING] Step 4.5: webhook enabled=%d, jpeg_buffer=%p, jpeg_copy=%p",
+                     wh_enabled, (void *)jpeg_buffer, (void *)jpeg_copy);
 
-        // Only push if buffer is confirmed to be a buffer_calloc allocation
-        if (jpeg_buffer && jpeg_copy && jpeg_buffer == jpeg_copy) {
-            aicam_result_t wh_ret = webhook_service_push_capture(
-                jpeg_buffer, (uint32_t)jpeg_size, &metadata, ai_result_ptr);
-            if (wh_ret == AICAM_OK) {
-                // Ownership transferred to webhook task — skip cleanup in Step 5
-                jpeg_buffer = NULL;
+        if (wh_enabled && jpeg_buffer) {
+            /* Webhook task uses buffer_free() to release jpeg_data, so the buffer
+             * must be a buffer_calloc allocation.  If jpeg_buffer is still the
+             * camera driver's buffer (jpeg_copy == NULL), make a heap copy and
+             * return the camera buffer immediately. */
+            if (!jpeg_copy) {
+                LOG_SVC_INFO("[TIMING] Step 4.5: copying jpeg (%d bytes) for webhook push", jpeg_size);
+                uint8_t *wh_buf = buffer_calloc(1, jpeg_size);
+                if (wh_buf) {
+                    memcpy(wh_buf, jpeg_buffer, jpeg_size);
+                    device_service_camera_free_jpeg_buffer(jpeg_buffer);
+                    jpeg_buffer = wh_buf;
+                    jpeg_copy = wh_buf;
+                } else {
+                    LOG_SVC_WARN("Webhook: failed to copy jpeg for push (size=%d)", jpeg_size);
+                }
             }
+
+            // Only push if buffer is confirmed to be a buffer_calloc allocation
+            LOG_SVC_INFO("[TIMING] Step 4.5: buffer check: jpeg_buffer=%p, jpeg_copy=%p, equal=%d",
+                         (void *)jpeg_buffer, (void *)jpeg_copy,
+                         (jpeg_buffer && jpeg_copy && jpeg_buffer == jpeg_copy));
+            if (jpeg_buffer && jpeg_copy && jpeg_buffer == jpeg_copy) {
+                aicam_result_t wh_ret = webhook_service_push_capture(
+                    jpeg_buffer, (uint32_t)jpeg_size, &metadata, ai_result_ptr);
+                LOG_SVC_INFO("[TIMING] Step 4.5: push_capture returned %d", wh_ret);
+                if (wh_ret == AICAM_OK) {
+                    // Ownership transferred to webhook task — skip cleanup in Step 5
+                    jpeg_buffer = NULL;
+                }
+            }
+        } else {
+            LOG_SVC_INFO("[TIMING] Step 4.5 SKIPPED: enabled=%d, jpeg_buffer=%p",
+                         wh_enabled, (void *)jpeg_buffer);
         }
+    }
+
+    // Step 4.6: Wait for webhook push to complete (needed for sleep wake-up)
+    if (!jpeg_buffer && webhook_service_is_enabled()) {
+        step_start_time = rtc_get_uptime_ms();
+        /* Worst case: 10s network wait + 15s HTTP timeout = 25s */
+        aicam_result_t wh_wait = webhook_service_wait_pending(30000);
+        step_end_time = rtc_get_uptime_ms();
+        step_duration = step_end_time - step_start_time;
+        LOG_SVC_INFO("[TIMING] Step 4.6: Webhook wait %s (duration: %lu ms)",
+                     wh_wait == AICAM_OK ? "completed" : "timed out",
+                     (unsigned long)step_duration);
+    } else if (jpeg_buffer) {
+        LOG_SVC_INFO("[TIMING] Step 4.6 SKIPPED: push was not queued (jpeg_buffer=%p)", (void *)jpeg_buffer);
     }
 
     // Step 5: Cleanup

--- a/Custom/Services/System/system_service.c
+++ b/Custom/Services/System/system_service.c
@@ -1027,7 +1027,7 @@ static void scheduled_interval_timer_callback(void *user_data)
      switch (timer_config->capture_mode) {
          case AICAM_TIMER_CAPTURE_MODE_INTERVAL:
              if (timer_config->interval_mode == AICAM_TIMER_INTERVAL_MODE_SCHEDULED &&
-                 timer_config->start_time > 0 && timer_config->interval_sec > 0) {
+                 timer_config->interval_sec > 0) {
                  // Scheduled interval: continuous 24-hour cycle anchored at start_time
                  RTC_TIME_S now_rtc = rtc_get_time();
                  uint32_t now_sec = now_rtc.hour * 3600 + now_rtc.minute * 60 + now_rtc.second;
@@ -1322,7 +1322,7 @@ aicam_result_t system_controller_get_next_capture_at(
 
     switch (tc->capture_mode) {
     case AICAM_TIMER_CAPTURE_MODE_INTERVAL:
-        if (tc->interval_mode == AICAM_TIMER_INTERVAL_MODE_SCHEDULED && tc->start_time > 0) {
+        if (tc->interval_mode == AICAM_TIMER_INTERVAL_MODE_SCHEDULED) {
             uint32_t next = calculate_next_scheduled_interval_trigger(
                 tc->start_time, tc->interval_sec, now_sec);
             // If next <= now_sec, it means the trigger wraps to tomorrow

--- a/Custom/Services/System/system_service.c
+++ b/Custom/Services/System/system_service.c
@@ -3574,51 +3574,38 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
                      (unsigned long)step_duration);
     }
 
-    step_start_time = rtc_get_uptime_ms();
-    LOG_SVC_INFO("[TIMING] Step 3.1: Checking MQTT network connection...");
-    uint32_t current_flags = service_get_ready_flags();
+    aicam_result_t upload_result = AICAM_ERROR;
+    aicam_bool_t mqtt_available = mqtt_service_is_running();
 
-    if (g_fast_fail_mqtt_policy) {
+    step_start_time = rtc_get_uptime_ms();
+
+    if (!mqtt_available) {
+        LOG_SVC_INFO("[TIMING] Step 3.1 SKIPPED: MQTT service not running — skip to webhook/SD");
+    } else if (g_fast_fail_mqtt_policy) {
         if (!mqtt_service_is_connected()) {
-            LOG_SVC_ERROR("[TIMING] Step 3.1 FAST-FAIL: MQTT not connected (flags=0x%08X)", current_flags);
-            if (jpeg_copy && jpeg_buffer == jpeg_copy) {
-                buffer_free(jpeg_buffer);
-            } else {
-                device_service_camera_free_jpeg_buffer(jpeg_buffer);
-            }
-            jpeg_buffer = NULL;
-            jpeg_copy = NULL;
-            return AICAM_ERROR_UNAVAILABLE;
+            LOG_SVC_INFO("[TIMING] Step 3.1 FAST-FAIL: MQTT not connected — skip MQTT, try webhook/SD");
+            mqtt_available = AICAM_FALSE;
         }
     } else {
-        LOG_SVC_INFO("[TIMING] Step 3.1: Current service flags: 0x%08X, MQTT_NET_CONNECTED: %s", 
+        LOG_SVC_INFO("[TIMING] Step 3.1: Checking MQTT network connection...");
+        uint32_t current_flags = service_get_ready_flags();
+        LOG_SVC_INFO("[TIMING] Step 3.1: Current service flags: 0x%08X, MQTT_NET_CONNECTED: %s",
                      current_flags, (current_flags & MQTT_NET_CONNECTED) ? "YES" : "NO");
         aicam_result_t result = service_wait_for_ready(MQTT_NET_CONNECTED, AICAM_TRUE, 15000);
         if (result != AICAM_OK) {
-            LOG_SVC_ERROR("[TIMING] Step 3.1 FAILED: Failed to wait for MQTT network connected: %d (timeout: 15s)", result);
-            LOG_SVC_ERROR("[TIMING] Step 3.1: Final service flags: 0x%08X", service_get_ready_flags());
-            if (jpeg_copy && jpeg_buffer == jpeg_copy) {
-                buffer_free(jpeg_buffer);
-            } else {
-                device_service_camera_free_jpeg_buffer(jpeg_buffer);
-            }
-            jpeg_buffer = NULL;
-            jpeg_copy = NULL;
-            return AICAM_ERROR_TIMEOUT;
+            LOG_SVC_INFO("[TIMING] Step 3.1 FAILED: MQTT network not ready: %d — skip MQTT, try webhook/SD", result);
+            LOG_SVC_INFO("[TIMING] Step 3.1: Final service flags: 0x%08X", service_get_ready_flags());
+            mqtt_available = AICAM_FALSE;
         }
     }
 
     step_end_time = rtc_get_uptime_ms();
     step_duration = step_end_time - step_start_time;
-    LOG_SVC_INFO("[TIMING] Step 3.1 COMPLETED: MQTT network ready (duration: %lu ms)", 
-                 (unsigned long)step_duration);
+    LOG_SVC_INFO("[TIMING] Step 3.1 COMPLETED: duration: %lu ms", (unsigned long)step_duration);
 
     // Step 4: Check MQTT connection and upload
     step_start_time = rtc_get_uptime_ms();
-    LOG_SVC_INFO("[TIMING] Step 4: Checking MQTT connection and uploading...");
-    aicam_result_t upload_result = AICAM_ERROR;
-    
-    if (mqtt_service_is_connected()) {
+    if (mqtt_available && mqtt_service_is_connected()) {
         LOG_SVC_INFO("[TIMING] MQTT connected - uploading image");
         
         // Determine upload method based on image size
@@ -3677,10 +3664,14 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
         }
         step_end_time = rtc_get_uptime_ms();
         step_duration = step_end_time - step_start_time;
-        LOG_SVC_INFO("[TIMING] Step 4 COMPLETED: MQTT upload finished (duration: %lu ms)", 
+        LOG_SVC_INFO("[TIMING] Step 4 COMPLETED: MQTT upload finished (duration: %lu ms)",
+                     (unsigned long)step_duration);
+    } else {
+        step_end_time = rtc_get_uptime_ms();
+        step_duration = step_end_time - step_start_time;
+        LOG_SVC_INFO("[TIMING] Step 4 SKIPPED: MQTT not available (duration: %lu ms)",
                      (unsigned long)step_duration);
     }
-
 
     // Step 4.5: Webhook push (non-blocking, fire-and-forget)
     if (webhook_service_is_enabled() && jpeg_buffer) {

--- a/Custom/Services/Web/api/api_device_module.c
+++ b/Custom/Services/Web/api/api_device_module.c
@@ -28,6 +28,8 @@
 /* ==================== Helper Functions ==================== */
 
 static uint32_t restart_delay_seconds = 3;
+static uint8_t s_restart_task_stack[1024];
+static uint32_t s_restart_delay_storage;
 
 /**
  * @brief Restart task function
@@ -1630,29 +1632,25 @@ aicam_result_t system_restart_handler(http_handler_context_t *ctx) {
     // Log restart request
     LOG_SVC_INFO("System restart requested via API - Delay: %u seconds", restart_delay_seconds);
 
-    uint8_t* restart_stack = buffer_calloc(1, 1024);
-    if (!restart_stack) {
-        LOG_SVC_ERROR("Failed to allocate restart stack");
-        return api_response_error(ctx, API_ERROR_INTERNAL_ERROR, "Failed to allocate restart stack");
-    }
-    
-    // Create a task to handle delayed restart
-    osThreadAttr_t restart_task_attr = {
-        .name = "restart_task",
-        .stack_size = 1024,
-        .priority = osPriorityHigh,
-        .stack_mem = restart_stack
-    };
-        
     // Schedule system restart with delay
     if (restart_delay_seconds > 0) {
         LOG_SVC_INFO("System will restart in %u seconds...", restart_delay_seconds);
-        
-        // Create restart task with delay
-        osThreadId_t restart_task = osThreadNew(restart_task_function, &restart_delay_seconds, &restart_task_attr);
-        
+
+        s_restart_delay_storage = restart_delay_seconds;
+
+        // Use pre-allocated static stack to avoid memory fragmentation after OTA
+        osThreadAttr_t restart_task_attr = {
+            .name = "restart_task",
+            .stack_size = 1024,
+            .priority = osPriorityHigh,
+            .stack_mem = s_restart_task_stack
+        };
+
+        osThreadId_t restart_task = osThreadNew(restart_task_function, &s_restart_delay_storage, &restart_task_attr);
+
         if (!restart_task) {
-            LOG_SVC_ERROR("Failed to create restart task, restarting immediately");
+            LOG_SVC_WARN("Failed to create restart task, using inline delayed restart");
+            osDelay(restart_delay_seconds * 1000);
 #if ENABLE_U0_MODULE
             u0_module_clear_wakeup_flag();
             u0_module_reset_chip_n6();

--- a/Custom/Services/Web/api/api_rtsp_module.c
+++ b/Custom/Services/Web/api/api_rtsp_module.c
@@ -38,7 +38,7 @@ static aicam_result_t rtsp_config_get_handler(http_handler_context_t* ctx)
     cJSON_AddNumberToObject(response, "port", vs_config.rtsp_port);
     cJSON_AddStringToObject(response, "auth_mode", vs_config.rtsp_auth_mode[0] ? vs_config.rtsp_auth_mode : "none");
     cJSON_AddStringToObject(response, "username", vs_config.rtsp_username[0] ? vs_config.rtsp_username : "");
-    cJSON_AddStringToObject(response, "password", vs_config.rtsp_password[0] ? "******" : "");
+    cJSON_AddStringToObject(response, "password", vs_config.rtsp_password[0] ? vs_config.rtsp_password : "");
 
     char *json_str = cJSON_Print(response);
     cJSON_Delete(response);
@@ -75,6 +75,15 @@ static aicam_result_t rtsp_config_set_handler(http_handler_context_t* ctx)
     json_config_get_video_stream_mode(&vs_config);
 
     aicam_bool_t was_enabled = vs_config.rtsp_enable;
+
+    /* Snapshot old values before modification */
+    uint16_t old_port = vs_config.rtsp_port;
+    char old_auth_mode[sizeof(vs_config.rtsp_auth_mode)];
+    char old_username[sizeof(vs_config.rtsp_username)];
+    char old_password[sizeof(vs_config.rtsp_password)];
+    strncpy(old_auth_mode, vs_config.rtsp_auth_mode, sizeof(old_auth_mode));
+    strncpy(old_username, vs_config.rtsp_username, sizeof(old_username));
+    strncpy(old_password, vs_config.rtsp_password, sizeof(old_password));
 
     /* Update fields if provided */
     cJSON *enabled = cJSON_GetObjectItem(request, "enabled");
@@ -130,6 +139,19 @@ static aicam_result_t rtsp_config_set_handler(http_handler_context_t* ctx)
         rtsp_service_start();
     } else if (!vs_config.rtsp_enable && was_enabled) {
         rtsp_service_stop();
+    } else if (vs_config.rtsp_enable && was_enabled) {
+        /* Already running — check if runtime config changed (port, auth) */
+        aicam_bool_t config_changed =
+            (vs_config.rtsp_port != old_port) ||
+            (strncmp(vs_config.rtsp_auth_mode, old_auth_mode, sizeof(vs_config.rtsp_auth_mode)) != 0) ||
+            (strncmp(vs_config.rtsp_username, old_username, sizeof(vs_config.rtsp_username)) != 0) ||
+            (strncmp(vs_config.rtsp_password, old_password, sizeof(vs_config.rtsp_password)) != 0);
+
+        if (config_changed) {
+            LOG_SVC_INFO("RTSP: runtime config changed, restarting service");
+            rtsp_service_stop();
+            rtsp_service_start();
+        }
     }
 
     cJSON *response = cJSON_CreateObject();

--- a/Custom/Services/Webhook/webhook_service.c
+++ b/Custom/Services/Webhook/webhook_service.c
@@ -256,6 +256,9 @@ aicam_result_t webhook_service_stop(void)
 
     if (g_webhook.task_handle) {
         osThreadJoin(g_webhook.task_handle);
+        /* osThreadJoin only waits but does NOT release the ThreadX TCB.
+         * osThreadTerminate calls tx_thread_delete to free kernel resources. */
+        osThreadTerminate(g_webhook.task_handle);
         g_webhook.task_handle = NULL;
     }
 

--- a/Custom/Services/Webhook/webhook_service.c
+++ b/Custom/Services/Webhook/webhook_service.c
@@ -18,6 +18,7 @@
 #include "nn.h"
 #include "cJSON.h"
 #include "device_service.h"
+#include "communication_service.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -166,6 +167,7 @@ static struct {
     osThreadId_t task_handle;
     uint32_t push_count;
     uint32_t fail_count;
+    volatile aicam_bool_t push_in_progress;
 } g_webhook;
 
 static uint8_t webhook_task_stack[WEBHOOK_TASK_STACK] __attribute__((aligned(32))) IN_PSRAM;
@@ -306,13 +308,26 @@ aicam_result_t webhook_service_push_capture(
     const mqtt_image_metadata_t *metadata,
     const mqtt_ai_result_t *ai_result)
 {
-    if (!jpeg_data || jpeg_size == 0) return AICAM_ERROR_INVALID_PARAM;
+    if (!jpeg_data || jpeg_size == 0) {
+        LOG_SVC_WARN("Webhook push_capture: invalid params (data=%p, size=%lu)",
+                     (const void *)jpeg_data, (unsigned long)jpeg_size);
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+
+    if (!g_webhook.running) {
+        LOG_SVC_ERROR("Webhook push_capture: service not running!");
+        return AICAM_ERROR;
+    }
 
     webhook_config_t cfg;
     if (json_config_get_webhook_config(&cfg) != AICAM_OK || !cfg.enable) {
-        LOG_SVC_DEBUG("Webhook: disabled, skipping push");
+        LOG_SVC_WARN("Webhook push_capture: disabled or config read failed (enable=%d)", cfg.enable);
         return AICAM_ERROR;
     }
+
+    LOG_SVC_INFO("Webhook push_capture: enqueuing %lu bytes, queue count=%lu",
+                 (unsigned long)jpeg_size,
+                 (unsigned long)osMessageQueueGetCount(g_webhook.queue));
 
     webhook_push_msg_t *msg = buffer_calloc(1, sizeof(webhook_push_msg_t));
     if (!msg) {
@@ -342,14 +357,23 @@ aicam_result_t webhook_service_push_capture(
         }
     }
 
+    /* Mark push in progress BEFORE enqueuing — prevents wait_pending from
+     * seeing queue=0 + push_in_progress=0 if the task consumes the message
+     * before wait_pending gets a chance to poll. */
+    g_webhook.push_in_progress = AICAM_TRUE;
+
     osStatus_t status = osMessageQueuePut(g_webhook.queue, &msg, 0, 0);
     if (status != osOK) {
-        LOG_SVC_WARN("Webhook: queue full, dropping push");
+        LOG_SVC_WARN("Webhook: queue put failed (status=%d, count=%lu)",
+                     status, (unsigned long)osMessageQueueGetCount(g_webhook.queue));
+        g_webhook.push_in_progress = AICAM_FALSE;
         if (msg->ai_result_json) cJSON_free(msg->ai_result_json);
         buffer_free(msg);
         return AICAM_ERROR;
     }
 
+    LOG_SVC_INFO("Webhook push_capture: enqueued OK (queue count=%lu)",
+                 (unsigned long)osMessageQueueGetCount(g_webhook.queue));
     return AICAM_OK;
 }
 
@@ -391,6 +415,32 @@ aicam_result_t webhook_service_test_push(void)
     return webhook_do_push(test_jpeg, sizeof(test_jpeg), NULL, NULL);
 }
 
+aicam_result_t webhook_service_wait_pending(uint32_t timeout_ms)
+{
+    if (!g_webhook.running || !g_webhook.queue) {
+        LOG_SVC_WARN("Webhook wait_pending: service not running (running=%d, queue=%p)",
+                     g_webhook.running, (void *)g_webhook.queue);
+        return AICAM_OK;
+    }
+
+    LOG_SVC_INFO("Webhook wait_pending: queue=%lu, push_in_progress=%d, timeout=%lu ms",
+                 (unsigned long)osMessageQueueGetCount(g_webhook.queue),
+                 g_webhook.push_in_progress, (unsigned long)timeout_ms);
+
+    uint32_t start = osKernelGetTickCount();
+    while (osMessageQueueGetCount(g_webhook.queue) > 0 || g_webhook.push_in_progress) {
+        if ((osKernelGetTickCount() - start) >= timeout_ms) {
+            LOG_SVC_WARN("Webhook: wait pending timed out after %lu ms (queue=%lu, push_in_progress=%d)",
+                         (unsigned long)timeout_ms,
+                         (unsigned long)osMessageQueueGetCount(g_webhook.queue),
+                         g_webhook.push_in_progress);
+            return AICAM_ERROR_TIMEOUT;
+        }
+        osDelay(50);
+    }
+    return AICAM_OK;
+}
+
 /* ==================== Push Task ==================== */
 
 static void webhook_push_task(void *arg)
@@ -410,8 +460,34 @@ static void webhook_push_task(void *arg)
         LOG_SVC_INFO("Webhook task: processing %lu bytes",
                      (unsigned long)msg->jpeg_size);
 
+        g_webhook.push_in_progress = AICAM_TRUE;
+
+        /* Wait for network connectivity before push.
+         * After sleep wake-up the interface may not be up yet. */
+        communication_type_t net_type = communication_get_current_type();
+        LOG_SVC_INFO("Webhook: network type=%d", net_type);
+        if (net_type == COMM_TYPE_NONE) {
+            LOG_SVC_INFO("Webhook: network not ready, waiting up to 10s...");
+            uint32_t wait_start = osKernelGetTickCount();
+            while (g_webhook.running &&
+                   communication_get_current_type() == COMM_TYPE_NONE) {
+                if ((osKernelGetTickCount() - wait_start) >= 10000) {
+                    LOG_SVC_WARN("Webhook: network wait timed out (10s)");
+                    break;
+                }
+                osDelay(500);
+            }
+            LOG_SVC_INFO("Webhook: network ready after %lu ms (type=%d)",
+                         (unsigned long)(osKernelGetTickCount() - wait_start),
+                         communication_get_current_type());
+        }
+
         aicam_result_t ret = webhook_do_push(msg->jpeg_data, msg->jpeg_size,
                                               &msg->metadata, msg->ai_result_json);
+        LOG_SVC_INFO("Webhook: push result=%d", ret);
+        g_webhook.push_in_progress = AICAM_FALSE;
+        LOG_SVC_INFO("Webhook: push done (total=%lu, fail=%lu)",
+                     (unsigned long)g_webhook.push_count, (unsigned long)g_webhook.fail_count);
 
         /* Free the JPEG buffer (caller transferred ownership) */
         buffer_free(msg->jpeg_data);

--- a/Custom/Services/Webhook/webhook_service.h
+++ b/Custom/Services/Webhook/webhook_service.h
@@ -45,6 +45,13 @@ aicam_result_t webhook_service_push_capture(
  */
 aicam_result_t webhook_service_test_push(void);
 
+/**
+ * @brief Wait until all queued webhook pushes complete
+ * @param timeout_ms Maximum wait time in milliseconds
+ * @return AICAM_OK if all pushes completed, AICAM_ERROR_TIMEOUT on timeout
+ */
+aicam_result_t webhook_service_wait_pending(uint32_t timeout_ms);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Custom/Services/service_init.c
+++ b/Custom/Services/service_init.c
@@ -251,7 +251,7 @@ static const service_module_t g_service_registry[] = {
         .config = NULL,
         .auto_start = AICAM_TRUE,
         .init_priority = 10,
-        .required_in_low_power = AICAM_FALSE,
+        .required_in_low_power = AICAM_TRUE,
         .depends_on = {"communication_service"},
         .depends_count = 1
     }

--- a/Web/src/locales/en/sys.json
+++ b/Web/src/locales/en/sys.json
@@ -394,6 +394,7 @@
       "update_loading": "Burning firmware, please wait",
       "please_select_firmware_file": "Please upload firmware file",
       "update_success": "Firmware burned successfully",
+      "device_restarting": "Device is restarting, please refresh the page later",
       "firmware_file_uploading": "Firmware file uploading",
       "no_network": "No network detected, please refresh the network",
       "firmware_upgrade_success": "Firmware burned successfully, please reconnect to the device",

--- a/Web/src/locales/zh/sys.json
+++ b/Web/src/locales/zh/sys.json
@@ -394,6 +394,7 @@
       "update_loading": "正在烧入固件，请稍后",
       "please_select_firmware_file": "请上传固件文件",
       "update_success": "固件烧录成功",
+      "device_restarting": "设备正在重启，请稍后刷新页面",
       "firmware_file_uploading": "固件文件上传中",
       "no_network": "未检测到网络,请刷新网络",
       "invalid_firmware_file": "固件文件无效",

--- a/Web/src/pages/deviceTool/rtsp-config.tsx
+++ b/Web/src/pages/deviceTool/rtsp-config.tsx
@@ -64,7 +64,7 @@ export default function RtspConfig() {
   const deviceIp = window.location.hostname;
 
   const streamUrl = config.enabled
-    ? `rtsp://${config.auth_mode === 'digest' && config.username ? `${config.username}:****@` : ''}${deviceIp}:${config.port}/live/stream`
+    ? `rtsp://${config.auth_mode === 'digest' && config.username ? `${config.username}:${config.password}@` : ''}${deviceIp}:${config.port}/live/stream`
     : '';
 
   const fetchConfig = async () => {

--- a/Web/src/pages/systemSettings/fireware/import-firmware.tsx
+++ b/Web/src/pages/systemSettings/fireware/import-firmware.tsx
@@ -1,5 +1,11 @@
 import { useRef, useState } from 'preact/hooks';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/dialog';
 import { Button } from '@/components/ui/button';
 import { useLingui } from '@lingui/react';
 import Upload from '@/components/upload';
@@ -11,279 +17,345 @@ import { retryFetch, sleep, sliceFile } from '@/utils';
 import { ScrollArea } from '@/components/ui/scroll-area';
 
 type ImportFirmwareProps = {
-    isImportFirmwareDialogOpen: boolean;
-    setIsImportFirmwareDialogOpen: (open: boolean) => void;
-}
-export default function ImportFirmware({ isImportFirmwareDialogOpen, setIsImportFirmwareDialogOpen }: ImportFirmwareProps) {
-    const { i18n } = useLingui();
-    const { uploadOTAFileReq, preCheckReq, updateOTAReq, restartDevice, uploadDeviceFileReq, getDeviceInfoReq } = systemApis;
-    const [appFile, setAppFile] = useState<File | null>(null);
-    const [webFile, setWebFile] = useState<File | null>(null);
-    const [aiModelFile, setAiModelFile] = useState<File | null>(null);
-    const [deviceFile, setDeviceFile] = useState<File | null>(null);
-    // const [updateLoadingValue, setUpdateLoadingValue] = useState(10);
-    const [isUpdateLoading, setIsUpdateLoading] = useState(false);
-    const [restartLoading, setRestartLoading] = useState(false);
-    const [uploadLoadings, setUploadLoadings] = useState({
-        app: false,
-        web: false,
-        ai: false,
-        // fsbl: false,
-        device: false,
-    });
-    type UploadCategory = keyof Pick<typeof uploadLoadings, 'app' | 'web' | 'ai'>;
-    const uploadQueueRef = useRef<Promise<void>>(Promise.resolve());
+  isImportFirmwareDialogOpen: boolean;
+  setIsImportFirmwareDialogOpen: (open: boolean) => void;
+};
+export default function ImportFirmware({
+  isImportFirmwareDialogOpen,
+  setIsImportFirmwareDialogOpen,
+}: ImportFirmwareProps) {
+  const { i18n } = useLingui();
+  const {
+    uploadOTAFileReq,
+    preCheckReq,
+    updateOTAReq,
+    restartDevice,
+    uploadDeviceFileReq,
+    getDeviceInfoReq,
+  } = systemApis;
+  const [appFile, setAppFile] = useState<File | null>(null);
+  const [webFile, setWebFile] = useState<File | null>(null);
+  const [aiModelFile, setAiModelFile] = useState<File | null>(null);
+  const [deviceFile, setDeviceFile] = useState<File | null>(null);
+  // const [updateLoadingValue, setUpdateLoadingValue] = useState(10);
+  const [isUpdateLoading, setIsUpdateLoading] = useState(false);
+  const [restartLoading, setRestartLoading] = useState(false);
+  const [uploadLoadings, setUploadLoadings] = useState({
+    app: false,
+    web: false,
+    ai: false,
+    // fsbl: false,
+    device: false,
+  });
+  type UploadCategory = keyof Pick<typeof uploadLoadings, 'app' | 'web' | 'ai'>;
+  const uploadQueueRef = useRef<Promise<void>>(Promise.resolve());
 
-    const acceptFileType = {
-        // Only accept .bin firmware files
-        'application/octet-stream': ['.bin'],
-    };
-    // Compatible with different browsers/systems' MIME declarations for JSON
-    const acceptDeviceFileType = {
-        'application/json': ['.json'],
+  const acceptFileType = {
+    // Only accept .bin firmware files
+    'application/octet-stream': ['.bin'],
+  };
+  // Compatible with different browsers/systems' MIME declarations for JSON
+  const acceptDeviceFileType = {
+    'application/json': ['.json'],
+  };
 
-    };
-
-    const uploadBtnSlot = (
-        <>
-            <SvgIcon icon="upload" />
-            {i18n._('common.reupload')}
-        </>
-    )
-    const customUpload = ({ placeholder, fileName, type }: { placeholder: string, fileName: string, type: string }) => (
-        <div className="flex flex-col gap-2 flex-1 items-center justify-center w-full h-full rounded-md">
-            {
-                fileName ? (
-                    <div className="flex flex-col items-center justify-center gap-2 h-full">
-                        <div className="flex flex-col items-center gap-2">
-                            <div className="w-14 h-14 bg-gray-400 rounded-md flex items-center justify-center">
-                                <SvgIcon className="w-10 h-10" icon="file" />
-                            </div>
-                            <p className="text-sm items-center  text-wrap text-text-primary">{fileName}</p>
-                        </div>
-                        <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-2">
-                            <Upload
-                              onFileChange={(file: File) => onFileChange(file, type)}
-                              slot={uploadBtnSlot}
-                              className="flex flex-1 h-full justify-start"
-                              type="button"
-                              accept={acceptFileType}
-                              maxFiles={1}
-                              maxSize={1024 * 1024 * 10}
-                              multiple={false}
-                            />
-                        </div>
-                    </div>
-                ) : (
-                    <div
-                      className="w-full relative flex-1 py-8 flex flex-col items-center justify-center pointer-events-none"
-                    >
-                        <div className="w-16 mb-2">
-                            <SvgIcon className="w-10 h-10" icon="upload_single" />
-                        </div>
-                        <p className="text-sm text-text-secondary">
-                            {placeholder}
-                        </p>
-                    </div>
-                )
-            }
+  const uploadBtnSlot = (
+    <>
+      <SvgIcon icon='upload' />
+      {i18n._('common.reupload')}
+    </>
+  );
+  const customUpload = ({
+    placeholder,
+    fileName,
+    type,
+  }: {
+    placeholder: string;
+    fileName: string;
+    type: string;
+  }) => (
+    <div className='flex flex-col gap-2 flex-1 items-center justify-center w-full h-full rounded-md'>
+      {fileName ? (
+        <div className='flex flex-col items-center justify-center gap-2 h-full'>
+          <div className='flex flex-col items-center gap-2'>
+            <div className='w-14 h-14 bg-gray-400 rounded-md flex items-center justify-center'>
+              <SvgIcon className='w-10 h-10' icon='file' />
+            </div>
+            <p className='text-sm items-center  text-wrap text-text-primary'>
+              {fileName}
+            </p>
+          </div>
+          <div className='absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-2'>
+            <Upload
+              onFileChange={(file: File) => onFileChange(file, type)}
+              slot={uploadBtnSlot}
+              className='flex flex-1 h-full justify-start'
+              type='button'
+              accept={acceptFileType}
+              maxFiles={1}
+              maxSize={1024 * 1024 * 10}
+              multiple={false}
+            />
+          </div>
         </div>
-    )
-    const uploadOTAs = async (file: File, type: UploadCategory): Promise<boolean> => {
-        try {
-            const contentPreview = await sliceFile(file, 2048);
-            if (!contentPreview.size) {
-                throw new Error(i18n._('sys.system_management.invalid_firmware_file') || 'Invalid firmware file');
-            }
-            await preCheckReq(contentPreview, type as FirmwareType);
-            await uploadOTAFileReq(file, type as FirmwareType);
-            await updateOTAReq({
-                filename: file.name,
-                firmware_type: type,
-                validate_crc32: true,
-                validate_signature: true,
-                allow_downgrade: true,
-                auto_upgrade: true
-            });
-            if (type === 'app') {
-                setAppFile(file);
-            } else if (type === 'web') {
-                setWebFile(file);
-            } else if (type === 'ai') {
-                setAiModelFile(file);
-            }
-            return true;
-        } catch {
-            return false;
-        } finally {
-            setUploadLoadings(prev => ({ ...prev, [type]: false }));
-        }
+      ) : (
+        <div className='w-full relative flex-1 py-8 flex flex-col items-center justify-center pointer-events-none'>
+          <div className='w-16 mb-2'>
+            <SvgIcon className='w-10 h-10' icon='upload_single' />
+          </div>
+          <p className='text-sm text-text-secondary'>{placeholder}</p>
+        </div>
+      )}
+    </div>
+  );
+  const uploadOTAs = async (
+    file: File,
+    type: UploadCategory
+  ): Promise<boolean> => {
+    try {
+      const contentPreview = await sliceFile(file, 2048);
+      if (!contentPreview.size) {
+        throw new Error(
+          i18n._('sys.system_management.invalid_firmware_file') ||
+            'Invalid firmware file'
+        );
+      }
+      await preCheckReq(contentPreview, type as FirmwareType);
+      await uploadOTAFileReq(file, type as FirmwareType);
+      await updateOTAReq({
+        filename: file.name,
+        firmware_type: type,
+        validate_crc32: true,
+        validate_signature: true,
+        allow_downgrade: true,
+        auto_upgrade: true,
+      });
+      if (type === 'app') {
+        setAppFile(file);
+      } else if (type === 'web') {
+        setWebFile(file);
+      } else if (type === 'ai') {
+        setAiModelFile(file);
+      }
+      return true;
+    } catch {
+      return false;
+    } finally {
+      setUploadLoadings(prev => ({ ...prev, [type]: false }));
     }
-    const enqueueUpload = (task: (type: UploadCategory) => Promise<boolean>, type: UploadCategory) => {
-        setUploadLoadings(prev => ({ ...prev, [type as UploadCategory]: true }));
-        uploadQueueRef.current = uploadQueueRef.current
-            .catch(() => undefined)
-            .then(() => task(type as UploadCategory).catch(error => {
-                toast.error(error instanceof Error ? error.message : String(error));
-                throw error;
-            }))
-            .then(() => setUploadLoadings(prev => ({ ...prev, [type as UploadCategory]: false })));
-        return uploadQueueRef.current;
-    };
-    const handleUpdate = async () => {
-        try {
-            if (!appFile && !webFile && !aiModelFile && !deviceFile) {
-                toast.error(i18n._('sys.system_management.please_select_firmware_file'));
-                return;
-            }
-            for (const key in uploadLoadings) {
-                if (uploadLoadings[key as keyof typeof uploadLoadings]) {
-                    toast.error(i18n._('sys.system_management.firmware_file_uploading'));
-                    return;
-                }
-            }
-
-            setIsUpdateLoading(true);
-            setIsImportFirmwareDialogOpen(false);
-            setRestartLoading(true);
-            await restartDevice({ delay_seconds: 2 });
-            await sleep(8000);
-            const result = await retryFetch(getDeviceInfoReq, 3000, 3);
-
-            if (result) {
-                setIsUpdateLoading(false);
-                toast.success(i18n._('sys.system_management.update_success'));
-            }
-        } catch (error) {
-            toast.error(error instanceof Error ? error.message : String(error));
-        } finally {
-            setRestartLoading(false);
+  };
+  const enqueueUpload = (
+    task: (type: UploadCategory) => Promise<boolean>,
+    type: UploadCategory
+  ) => {
+    setUploadLoadings(prev => ({ ...prev, [type as UploadCategory]: true }));
+    uploadQueueRef.current = uploadQueueRef.current
+      .catch(() => undefined)
+      .then(() =>
+        task(type as UploadCategory).catch(error => {
+          toast.error(error instanceof Error ? error.message : String(error));
+          throw error;
+        })
+      )
+      .then(() =>
+        setUploadLoadings(prev => ({
+          ...prev,
+          [type as UploadCategory]: false,
+        }))
+      );
+    return uploadQueueRef.current;
+  };
+  const handleUpdate = async () => {
+    let upgradeSuccess = false;
+    try {
+      if (!appFile && !webFile && !aiModelFile && !deviceFile) {
+        toast.error(
+          i18n._('sys.system_management.please_select_firmware_file')
+        );
+        return;
+      }
+      for (const key in uploadLoadings) {
+        if (uploadLoadings[key as keyof typeof uploadLoadings]) {
+          toast.error(i18n._('sys.system_management.firmware_file_uploading'));
+          return;
         }
-    };
-    const onAppFileChange = (file: File) => {
-        enqueueUpload((type) => uploadOTAs(file, type), 'app');
-    };
-    const onWebFileChange = (files: File) => {
-        enqueueUpload((type) => uploadOTAs(files as File, type), 'web');
-    };
-    const onAIFileChange = (files: File) => {
-        enqueueUpload((type) => uploadOTAs(files, type), 'ai');
-    };
-    const onDeviceFileChange = (files: File) => {
-        uploadDeviceFile(files);
-    };
-    const onFileChange = (file: File, type: string) => {
-        if (type === 'app') {
-            onAppFileChange(file);
-        } else if (type === 'web') {
-            onWebFileChange(file);
-        } else if (type === 'ai') {
-            onAIFileChange(file);
-        } else if (type === 'device') {
-            uploadDeviceFile(file);
-        }
+      }
+
+      setIsUpdateLoading(true);
+      setIsImportFirmwareDialogOpen(false);
+      setRestartLoading(true);
+      await restartDevice({ delay_seconds: 2 });
+      await sleep(8000);
+      const result = await retryFetch(getDeviceInfoReq, 5000, 10);
+
+      if (result) {
+        upgradeSuccess = true;
+        setIsUpdateLoading(false);
+        toast.success(i18n._('sys.system_management.update_success'));
+      } else {
+        toast.warning(i18n._('sys.system_management.device_restarting'));
+      }
+    } catch {
+      // Device restarting, network unreachable is expected
+      toast.warning(i18n._('sys.system_management.device_restarting'));
+    } finally {
+      setRestartLoading(false);
+      if (!upgradeSuccess) {
+        // Delay close mask and reload page when device unreachable
+        setTimeout(() => {
+          setIsUpdateLoading(false);
+          window.location.reload();
+        }, 3000);
+      }
     }
-    const uploadDeviceFile = async (file: File) => {
-        try {
-            setUploadLoadings(prev => ({ ...prev, device: true }));
-            // Read text and validate JSON
-            const text = await file.text();
-            const data = JSON.parse(text);
-            await uploadDeviceFileReq(data);
-            setDeviceFile(file);
-            return true;
-        } catch {
-            return false;
-        } finally {
-            setUploadLoadings(prev => ({ ...prev, device: false }));
-        }
+  };
+  const onAppFileChange = (file: File) => {
+    enqueueUpload(type => uploadOTAs(file, type), 'app');
+  };
+  const onWebFileChange = (files: File) => {
+    enqueueUpload(type => uploadOTAs(files as File, type), 'web');
+  };
+  const onAIFileChange = (files: File) => {
+    enqueueUpload(type => uploadOTAs(files, type), 'ai');
+  };
+  const onDeviceFileChange = (files: File) => {
+    uploadDeviceFile(files);
+  };
+  const onFileChange = (file: File, type: string) => {
+    if (type === 'app') {
+      onAppFileChange(file);
+    } else if (type === 'web') {
+      onWebFileChange(file);
+    } else if (type === 'ai') {
+      onAIFileChange(file);
+    } else if (type === 'device') {
+      uploadDeviceFile(file);
     }
+  };
+  const uploadDeviceFile = async (file: File) => {
+    try {
+      setUploadLoadings(prev => ({ ...prev, device: true }));
+      // Read text and validate JSON
+      const text = await file.text();
+      const data = JSON.parse(text);
+      await uploadDeviceFileReq(data);
+      setDeviceFile(file);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      setUploadLoadings(prev => ({ ...prev, device: false }));
+    }
+  };
 
-    return (
-        <div>
-            {isUpdateLoading && <WifiReloadMask isLoading={restartLoading} loadingText={i18n._('sys.system_management.firmware_upgrade_desc')} maskText={i18n._('sys.system_management.firmware_upgrade_success')} />}
-            <Dialog
-              open={isImportFirmwareDialogOpen}
-              onOpenChange={setIsImportFirmwareDialogOpen}
+  return (
+    <div>
+      {isUpdateLoading && (
+        <WifiReloadMask
+          isLoading={restartLoading}
+          loadingText={i18n._('sys.system_management.firmware_upgrade_desc')}
+          maskText={i18n._('sys.system_management.firmware_upgrade_success')}
+        />
+      )}
+      <Dialog
+        open={isImportFirmwareDialogOpen}
+        onOpenChange={setIsImportFirmwareDialogOpen}
+      >
+        <DialogContent className='md:max-w-4xl mx-4'>
+          <DialogHeader>
+            <DialogTitle>
+              {i18n._('sys.system_management.header_import_firmware')}
+            </DialogTitle>
+            <ScrollArea className='h-[70vh] md:h-auto pt-2'>
+              <div className='flex flex-col gap-2'>
+                <p className='text-sm mt-2 self-start'>
+                  *{i18n._('sys.system_management.firmware_file')}
+                </p>
+                <div className='h-full w-full flex md:grid md:grid-cols-2 flex-col flex-1 justify-center items-center gap-4 mb-4'>
+                  <Upload
+                    className='h-50 w-full'
+                    type='customZone'
+                    slot={customUpload({
+                      placeholder: i18n._('sys.system_management.app_file'),
+                      fileName: appFile?.name || '',
+                      type: 'app',
+                    })}
+                    accept={acceptFileType}
+                    maxFiles={1}
+                    maxSize={1024 * 1024 * 10}
+                    multiple={false}
+                    onFileChange={onAppFileChange}
+                    loading={uploadLoadings.app}
+                  />
+                  <Upload
+                    className='h-50  w-full'
+                    type='customZone'
+                    slot={customUpload({
+                      placeholder: i18n._('sys.system_management.web_file'),
+                      fileName: webFile?.name || '',
+                      type: 'web',
+                    })}
+                    accept={acceptFileType}
+                    maxFiles={1}
+                    maxSize={1024 * 1024 * 10}
+                    multiple={false}
+                    onFileChange={onWebFileChange}
+                    loading={uploadLoadings.web}
+                  />
+                  <Upload
+                    className='h-50 w-full'
+                    type='customZone'
+                    slot={customUpload({
+                      placeholder: i18n._(
+                        'sys.system_management.ai_model_file'
+                      ),
+                      fileName: aiModelFile?.name || '',
+                      type: 'ai',
+                    })}
+                    accept={acceptFileType}
+                    maxFiles={1}
+                    maxSize={1024 * 1024 * 10}
+                    multiple={false}
+                    onFileChange={onAIFileChange}
+                    loading={uploadLoadings.ai}
+                  />
+                  <Upload
+                    className='h-50 w-full'
+                    type='customZone'
+                    slot={customUpload({
+                      placeholder: i18n._('sys.system_management.device_file'),
+                      fileName: deviceFile?.name || '',
+                      type: 'device',
+                    })}
+                    accept={acceptDeviceFileType}
+                    maxFiles={1}
+                    maxSize={1024 * 1024 * 50}
+                    multiple={false}
+                    onFileChange={onDeviceFileChange}
+                    loading={uploadLoadings.device}
+                  />
+                </div>
+              </div>
+            </ScrollArea>
+          </DialogHeader>
+          <DialogFooter className='mt-4'>
+            <Button
+              variant='outline'
+              className='w-1/2 md:w-auto'
+              onClick={() => setIsImportFirmwareDialogOpen(false)}
             >
-                <DialogContent className="md:max-w-4xl mx-4">
-                    <DialogHeader>
-                        <DialogTitle>
-                            {i18n._('sys.system_management.header_import_firmware')}
-                        </DialogTitle>
-                        <ScrollArea className="h-[70vh] md:h-auto pt-2">
-                            <div className="flex flex-col gap-2">
-                                <p className="text-sm mt-2 self-start">
-                                    *{i18n._('sys.system_management.firmware_file')}
-                                </p>
-                                <div className="h-full w-full flex md:grid md:grid-cols-2 flex-col flex-1 justify-center items-center gap-4 mb-4">
-                                    <Upload
-                                      className="h-50 w-full"
-                                      type="customZone"
-                                      slot={customUpload({ placeholder: i18n._('sys.system_management.app_file'), fileName: appFile?.name || '', type: 'app' })}
-                                      accept={acceptFileType}
-                                      maxFiles={1}
-                                      maxSize={1024 * 1024 * 10}
-                                      multiple={false}
-                                      onFileChange={onAppFileChange}
-                                      loading={uploadLoadings.app}
-                                    />
-                                    <Upload
-                                      className="h-50  w-full"
-                                      type="customZone"
-                                      slot={customUpload({ placeholder: i18n._('sys.system_management.web_file'), fileName: webFile?.name || '', type: 'web' })}
-                                      accept={acceptFileType}
-                                      maxFiles={1}
-                                      maxSize={1024 * 1024 * 10}
-                                      multiple={false}
-                                      onFileChange={onWebFileChange}
-                                      loading={uploadLoadings.web}
-                                    />
-                                    <Upload
-                                      className="h-50 w-full"
-                                      type="customZone"
-                                      slot={customUpload({ placeholder: i18n._('sys.system_management.ai_model_file'), fileName: aiModelFile?.name || '', type: 'ai' })}
-                                      accept={acceptFileType}
-                                      maxFiles={1}
-                                      maxSize={1024 * 1024 * 10}
-                                      multiple={false}
-                                      onFileChange={onAIFileChange}
-                                      loading={uploadLoadings.ai}
-                                    />
-                                    <Upload
-                                      className="h-50 w-full"
-                                      type="customZone"
-                                      slot={customUpload({ placeholder: i18n._('sys.system_management.device_file'), fileName: deviceFile?.name || '', type: 'device' })}
-                                      accept={acceptDeviceFileType}
-                                      maxFiles={1}
-                                      maxSize={1024 * 1024 * 50}
-                                      multiple={false}
-                                      onFileChange={onDeviceFileChange}
-                                      loading={uploadLoadings.device}
-                                    />
-                                </div>
-                            </div>
-                        </ScrollArea>
-                    </DialogHeader>
-                    <DialogFooter className="mt-4">
-                        <Button
-                          variant="outline"
-                          className="w-1/2 md:w-auto"
-                          onClick={() => setIsImportFirmwareDialogOpen(false)}
-                        >
-                            {i18n._('common.cancel')}
-                        </Button>
-                        <Button
-                          variant="primary"
-                          className="w-1/2 md:w-auto"
-                          onClick={() => handleUpdate()}
-                        >
-                            {i18n._('sys.system_management.confirm_burn')}
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-
-            </Dialog>
-        </div>
-    )
+              {i18n._('common.cancel')}
+            </Button>
+            <Button
+              variant='primary'
+              className='w-1/2 md:w-auto'
+              onClick={() => handleUpdate()}
+            >
+              {i18n._('sys.system_management.confirm_burn')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }


### PR DESCRIPTION
…ssing issue

- Remove `start_time > 0` check in scheduled interval timer callback and next-capture-time calculation. start_time=0 (midnight) is a valid value that was incorrectly excluded, causing wrong next capture time.
- Always call mbedtls_ssl_set_hostname() for TLS connections regardless of hostname verification setting. Modern servers require SNI extension to select the correct certificate; without it the handshake fails with a fatal alert (error -19968).