### PR TITLE
feat: add stream tab preference and fix upload result tracking

### DIFF
--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -327,6 +327,9 @@
  #define NVS_KEY_RTSP_USERNAME       "rtsp_user"
  #define NVS_KEY_RTSP_PASSWORD       "rtsp_pass"
 
+// UI preferences
+#define NVS_KEY_PREF_STREAM_TAB     "pref_stab"
+
 // Webhook configuration key names
 #define NVS_KEY_WEBHOOK_ENABLE      "wh_enable"
 #define NVS_KEY_WEBHOOK_URL         "wh_url"

--- a/Custom/Services/System/system_service.c
+++ b/Custom/Services/System/system_service.c
@@ -3574,6 +3574,8 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
     }
 
     aicam_result_t upload_result = AICAM_ERROR;
+    aicam_bool_t mqtt_uploaded = AICAM_FALSE;
+    aicam_bool_t webhook_succeeded = AICAM_FALSE;
     aicam_bool_t mqtt_available = mqtt_service_is_running();
 
     step_start_time = rtc_get_uptime_ms();
@@ -3626,9 +3628,10 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
             uint64_t upload_duration = upload_end_time - upload_start_time;
 
             if (mqtt_result >= 0) {
-                LOG_SVC_INFO("[TIMING] Image uploaded successfully (msg_id: %d, upload duration: %lu ms)", 
+                LOG_SVC_INFO("[TIMING] Image uploaded successfully (msg_id: %d, upload duration: %lu ms)",
                             mqtt_result, (unsigned long)upload_duration);
                 upload_result = AICAM_OK;
+                mqtt_uploaded = AICAM_TRUE;
             } else {
                 LOG_SVC_ERROR("[TIMING] Image upload failed: %d (upload duration: %lu ms)", 
                              mqtt_result, (unsigned long)upload_duration);
@@ -3652,9 +3655,10 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
             uint64_t upload_duration = upload_end_time - upload_start_time;
 
             if (mqtt_result > 0) {
-                LOG_SVC_INFO("[TIMING] Image uploaded in %d chunks (upload duration: %lu ms)", 
+                LOG_SVC_INFO("[TIMING] Image uploaded in %d chunks (upload duration: %lu ms)",
                             mqtt_result, (unsigned long)upload_duration);
                 upload_result = AICAM_OK;
+                mqtt_uploaded = AICAM_TRUE;
             } else {
                 LOG_SVC_ERROR("[TIMING] Chunked upload failed: %d (upload duration: %lu ms)", 
                              mqtt_result, (unsigned long)upload_duration);
@@ -3707,6 +3711,8 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
                 if (wh_ret == AICAM_OK) {
                     // Ownership transferred to webhook task — skip cleanup in Step 5
                     jpeg_buffer = NULL;
+                    upload_result = AICAM_OK;
+                    webhook_succeeded = AICAM_TRUE;
                 }
             }
         } else {
@@ -3746,8 +3752,8 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
     LOG_SVC_INFO("[TIMING] Step 5 COMPLETED: Cleanup finished (duration: %lu ms)", 
                  (unsigned long)step_duration);
 
-    // Step 6: Wait for publish confirmation (if upload was successful)
-    if (upload_result == AICAM_OK) {
+    // Step 6: Wait for MQTT publish confirmation (only if MQTT upload was performed)
+    if (mqtt_uploaded) {
         step_start_time = rtc_get_uptime_ms();
         LOG_SVC_INFO("[TIMING] Step 6: Waiting for publish confirmation...");
 
@@ -3761,7 +3767,9 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
 
         if(mqtt_service_wait_for_event(MQTT_EVENT_PUBLISHED, AICAM_TRUE, puback_timeout) != AICAM_OK){
             LOG_SVC_ERROR("[TIMING] Step 6 FAILED: Wait for published event failed");
-            upload_result = AICAM_ERROR;
+            if (!webhook_succeeded) {
+                upload_result = AICAM_ERROR;
+            }
         } else {
             step_end_time = rtc_get_uptime_ms();
             step_duration = step_end_time - step_start_time;

--- a/Custom/Services/Web/api/api_device_module.c
+++ b/Custom/Services/Web/api/api_device_module.c
@@ -18,6 +18,7 @@
 #include "stm32n6xx_hal_cortex.h"
 #include "generic_file.h"
 #include "json_config_mgr.h"
+#include "json_config_internal.h"
 #include "ai_service.h"
 #include "ota_service.h"
 #include "ota_header.h"
@@ -1845,8 +1846,48 @@ aicam_result_t device_config_import_handler(http_handler_context_t *ctx) {
     cJSON_Delete(response_json);
     
     LOG_SVC_INFO("Device configuration imported successfully");
-    
+
     return api_result;
+}
+
+/**
+ * @brief GET/POST /api/v1/device/preference/stream_tab - Get or set preferred stream tab
+ */
+aicam_result_t device_pref_stream_tab_handler(http_handler_context_t *ctx) {
+    if (!ctx) return AICAM_ERROR_INVALID_PARAM;
+
+    if (!web_api_verify_method(ctx, "GET") && !web_api_verify_method(ctx, "POST")) {
+        return api_response_error(ctx, API_ERROR_METHOD_NOT_ALLOWED, "Only GET and POST methods are allowed");
+    }
+
+    if (web_api_verify_method(ctx, "GET")) {
+        char value[8] = "rtmp";
+        json_config_nvs_read_string(NVS_KEY_PREF_STREAM_TAB, value, sizeof(value));
+        cJSON *json = cJSON_CreateObject();
+        cJSON_AddStringToObject(json, "stream_tab", value);
+        char *str = cJSON_Print(json);
+        cJSON_Delete(json);
+        return api_response_success(ctx, str, "OK");
+    }
+
+    // POST - save preference
+    cJSON *req = web_api_parse_body(ctx);
+    if (!req) {
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "Invalid JSON");
+    }
+    cJSON *item = cJSON_GetObjectItem(req, "stream_tab");
+    if (!item || !cJSON_IsString(item)) {
+        cJSON_Delete(req);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "stream_tab is required");
+    }
+    const char *tab = item->valuestring;
+    if (strcmp(tab, "rtmp") != 0 && strcmp(tab, "rtsp") != 0) {
+        cJSON_Delete(req);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "stream_tab must be 'rtmp' or 'rtsp'");
+    }
+    json_config_nvs_write_string(NVS_KEY_PREF_STREAM_TAB, tab);
+    cJSON_Delete(req);
+    return api_response_success(ctx, "{}", "Preference saved");
 }
 
 /**
@@ -2196,6 +2237,20 @@ static const api_route_t device_module_routes[] = {
         .method = "POST",
         .path = API_PATH_PREFIX "/device/config/import",
         .handler = device_config_import_handler,
+        .require_auth = AICAM_TRUE,
+        .user_data = NULL
+    },
+    {
+        .method = "GET",
+        .path = API_PATH_PREFIX "/device/preference/stream_tab",
+        .handler = device_pref_stream_tab_handler,
+        .require_auth = AICAM_TRUE,
+        .user_data = NULL
+    },
+    {
+        .method = "POST",
+        .path = API_PATH_PREFIX "/device/preference/stream_tab",
+        .handler = device_pref_stream_tab_handler,
         .require_auth = AICAM_TRUE,
         .user_data = NULL
     }

--- a/Web/src/pages/deviceTool/rtmp-config.tsx
+++ b/Web/src/pages/deviceTool/rtmp-config.tsx
@@ -99,7 +99,11 @@ export default function RtmpConfig() {
       state: 'idle',
     },
   });
-  const [currentMode, setCurrentMode] = useState<string>('rtmp');
+  const [currentMode, setCurrentModeRaw] = useState<string>('rtmp');
+  const setCurrentMode = (mode: string) => {
+    setCurrentModeRaw(mode);
+    deviceTool.setStreamTabPrefReq({ stream_tab: mode }).catch(() => {});
+  };
   const autoCheck = useRef(false);
   const [errors, setErrors] = useState<Errors>({
     url: {
@@ -116,6 +120,7 @@ export default function RtmpConfig() {
       setRtmpLoading(true);
       const res = await getRtmpConfigReq();
       setRtmpConfig(res.data);
+      return res.data;
     } catch (error) {
       console.error('initRtmpConfig', error);
       throw error;
@@ -176,7 +181,16 @@ export default function RtmpConfig() {
   const initRtmpData = async () => {
     try {
       setRtmpLoading(true);
-      await Promise.all([getRtmpConfig(), getRtmpStatus()]);
+      await Promise.all([
+        getRtmpConfig(),
+        getRtmpStatus(),
+        deviceTool
+          .getStreamTabPrefReq()
+          .then(res => {
+            if (res?.data?.stream_tab) setCurrentModeRaw(res.data.stream_tab);
+          })
+          .catch(() => {}),
+      ]);
     } catch (error) {
       console.error('initRtmpData', error);
       throw error;
@@ -188,6 +202,7 @@ export default function RtmpConfig() {
     try {
       const res = await getRtmpStatusReq();
       setRtmpStatus(res.data);
+      return res.data;
     } catch (error) {
       console.error('getRtmpStatus', error);
       throw error;

--- a/Web/src/pages/hardwareManagement/graphics.tsx
+++ b/Web/src/pages/hardwareManagement/graphics.tsx
@@ -34,7 +34,12 @@ import { toast } from 'sonner';
 export default function Graphics() {
   const { i18n } = useLingui();
   const { deviceInfo } = useSystemInfo();
-  const { getHardwareInfoReq, setHardwareInfoReq, getIspProfileExportReq, postIspProfileImportReq } = hardwareManagement;
+  const {
+    getHardwareInfoReq,
+    setHardwareInfoReq,
+    getIspProfileExportReq,
+    postIspProfileImportReq,
+  } = hardwareManagement;
   const { toggleAiReq, startVideoStreamReq, stopVideoStreamReq } = deviceTool;
   const [connectionStatus, setConnectionStatus] = useState('');
   const [brightness, setBrightness] = useState(0);
@@ -81,35 +86,36 @@ export default function Graphics() {
   let playerRender: H264Player | null = null;
   // ----------Skeleton screen
   const skeletonScreen = () => (
-    <div className="flex flex-col gap-2 w-full">
-      <div className="flex justify-between gap-4">
-        <Skeleton className="w-10 h-8" />
-        <Skeleton className="w-auto flex-1 h-8" />
+    <div className='flex flex-col gap-2 w-full'>
+      <div className='flex justify-between gap-4'>
+        <Skeleton className='w-10 h-8' />
+        <Skeleton className='w-auto flex-1 h-8' />
       </div>
-      <div className="flex justify-between gap-4">
-        <Skeleton className="w-10 h-8" />
-        <Skeleton className="w-auto flex-1 h-8" />
+      <div className='flex justify-between gap-4'>
+        <Skeleton className='w-10 h-8' />
+        <Skeleton className='w-auto flex-1 h-8' />
       </div>
-      <div className="flex justify-between">
-        <Skeleton className="w-10 h-8" />
-        <Skeleton className="w-10 h-8" />
+      <div className='flex justify-between'>
+        <Skeleton className='w-10 h-8' />
+        <Skeleton className='w-10 h-8' />
       </div>
-      <div className="flex justify-between gap-2">
-        <Skeleton className="w-10 h-8" />
-        <Skeleton className="w-10 h-8" />
+      <div className='flex justify-between gap-2'>
+        <Skeleton className='w-10 h-8' />
+        <Skeleton className='w-10 h-8' />
       </div>
     </div>
   );
-  const initData = () => (deviceInfo?.camera_module
-    ? setConnectionStatus('connected')
-    : setConnectionStatus('disconnected'));
+  const initData = () =>
+    deviceInfo?.camera_module
+      ? setConnectionStatus('connected')
+      : setConnectionStatus('disconnected');
   const initPlayer = async () => {
     try {
       setPlayerLoading(true);
       await startVideoStreamReq();
       if (!playerRef.current) return;
       const video = playerRef.current;
-      playerRender = new H264Player(() => { });
+      playerRender = new H264Player(() => {});
       playerRender.initPlayer(video);
       playerRender.start(getWebSocketUrl());
     } catch (error) {
@@ -182,7 +188,7 @@ export default function Graphics() {
       fast_capture_jpeg_quality: number;
       capture_disable_comm: boolean;
       capture_storage_ai: boolean;
-    }> = {},
+    }> = {}
   ) => ({
     brightness: overrides.brightness ?? brightness,
     contrast: overrides.contrast ?? contrast,
@@ -190,14 +196,20 @@ export default function Graphics() {
     vertical_flip: overrides.vertical_flip ?? flipVertical,
     aec: overrides.aec ?? aec,
     isp_mode: overrides.isp_mode ?? ispMode,
-    fast_capture_skip_frames: overrides.fast_capture_skip_frames ?? fastSkipFrames,
-    fast_capture_resolution: overrides.fast_capture_resolution ?? fastResolution,
-    fast_capture_jpeg_quality: overrides.fast_capture_jpeg_quality ?? fastJpegQuality,
+    fast_capture_skip_frames:
+      overrides.fast_capture_skip_frames ?? fastSkipFrames,
+    fast_capture_resolution:
+      overrides.fast_capture_resolution ?? fastResolution,
+    fast_capture_jpeg_quality:
+      overrides.fast_capture_jpeg_quality ?? fastJpegQuality,
     capture_disable_comm: overrides.capture_disable_comm ?? captureDisableComm,
     capture_storage_ai: overrides.capture_storage_ai ?? captureStorageAi,
   });
 
-  const handleFastCaptureChange = (type: 'fast_skip_frames' | 'fast_jpeg_quality', rawValue: number) => {
+  const handleFastCaptureChange = (
+    type: 'fast_skip_frames' | 'fast_jpeg_quality',
+    rawValue: number
+  ) => {
     let value = rawValue;
     if (Number.isNaN(value)) {
       value = 0;
@@ -213,7 +225,10 @@ export default function Graphics() {
     }
   };
 
-  const postFastCapture = async (type: 'fast_skip_frames' | 'fast_jpeg_quality', rawValue: number) => {
+  const postFastCapture = async (
+    type: 'fast_skip_frames' | 'fast_jpeg_quality',
+    rawValue: number
+  ) => {
     // Keep exactly aligned with deviceTool: always submit the incoming value for this request
     let value = rawValue;
     if (Number.isNaN(value)) {
@@ -222,8 +237,10 @@ export default function Graphics() {
     if (type === 'fast_skip_frames') {
       if (value < 0) value = 0;
       else if (value > 300) value = 300;
-    } else if (value < 0) value = 0;
+    } else {
+      if (value < 0) value = 0;
       else if (value > 100) value = 100;
+    }
 
     const nextSkip = type === 'fast_skip_frames' ? value : fastSkipFrames;
     const nextQuality = type === 'fast_jpeg_quality' ? value : fastJpegQuality;
@@ -233,7 +250,7 @@ export default function Graphics() {
         buildImageConfigRequest({
           fast_capture_skip_frames: nextSkip,
           fast_capture_jpeg_quality: nextQuality,
-        }),
+        })
       );
     } catch (error) {
       console.error(error);
@@ -247,9 +264,9 @@ export default function Graphics() {
     let nextFlipHorizontal = flipHorizontal;
     let nextFlipVertical = flipVertical;
     let nextAec = aec;
-    const nextFastSkipFrames = fastSkipFrames;
+    let nextFastSkipFrames = fastSkipFrames;
     let nextFastResolution = fastResolution;
-    const nextFastJpegQuality = fastJpegQuality;
+    let nextFastJpegQuality = fastJpegQuality;
 
     switch (type) {
       case 'brightness':
@@ -291,7 +308,7 @@ export default function Graphics() {
           fast_capture_skip_frames: nextFastSkipFrames,
           fast_capture_resolution: nextFastResolution,
           fast_capture_jpeg_quality: nextFastJpegQuality,
-        }),
+        })
       );
     } catch (error) {
       console.error(error);
@@ -309,31 +326,30 @@ export default function Graphics() {
         <div
           className={`flex flex-col gap-2 mt-4 ${loading ? '' : 'bg-gray-100'} p-4 rounded-lg`}
         >
-          <div className="flex justify-between">
+          <div className='flex justify-between'>
             <Label>{i18n._('sys.hardware_management.connection_status')}</Label>
-            <div className="flex items-center gap-2">
+            <div className='flex items-center gap-2'>
               <div
                 className={`w-2 h-2 rounded-full ${connectionStatus === 'connected' ? 'bg-green-500' : 'bg-gray-500'}`}
-              >
-              </div>
+              ></div>
               <p>{i18n._(`common.${connectionStatus}`)}</p>
             </div>
           </div>
           {connectionStatus === 'connected' && (
             <>
               <Separator />
-              <div className="flex justify-between relative bg-black">
+              <div className='flex justify-between relative bg-black'>
                 <video
                   ref={playerRef as React.Ref<HTMLVideoElement>}
-                  id="player"
-                  className="w-full aspect-video"
+                  id='player'
+                  className='w-full aspect-video'
                   muted
                   playsInline
                   disableRemotePlayback
                 />
                 {playerLoading && (
-                  <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
-                    <Loading placeholder="Loading..." />
+                  <div className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2'>
+                    <Loading placeholder='Loading...' />
                   </div>
                 )}
               </div>
@@ -343,16 +359,18 @@ export default function Graphics() {
                 <>
                   <Separator />
                   {/* Camera configuration (flip etc.) */}
-                  <div className="flex flex-col gap-2">
+                  <div className='flex flex-col gap-2'>
                     <button
-                      type="button"
-                      className="flex w-full items-center justify-between text-left"
-                      onClick={() => setCameraSectionOpen((o) => !o)}
+                      type='button'
+                      className='flex w-full items-center justify-between text-left'
+                      onClick={() => setCameraSectionOpen(o => !o)}
                     >
-                      <Label>{i18n._('sys.hardware_management.camera_config')}</Label>
-                      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500">
+                      <Label>
+                        {i18n._('sys.hardware_management.camera_config')}
+                      </Label>
+                      <span className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500'>
                         <SvgIcon
-                          icon="right"
+                          icon='right'
                           className={`h-4 w-4 transition-transform duration-200 ${
                             cameraSectionOpen ? 'rotate-90' : 'rotate-0'
                           }`}
@@ -360,119 +378,176 @@ export default function Graphics() {
                       </span>
                     </button>
                     {cameraSectionOpen && (
-                      <div className="border border-gray-200 border-solid p-4 rounded-md mt-2 flex flex-col gap-2">
-                        <div className="flex justify-between">
+                      <div className='border border-gray-200 border-solid p-4 rounded-md mt-2 flex flex-col gap-2'>
+                        <div className='flex justify-between'>
                           <Label>
                             {i18n._('sys.hardware_management.flip_horizontal')}
                           </Label>
                           <Switch
                             checked={flipHorizontal}
-                            onCheckedChange={() => handleSetHardwareInfo(
-                              'flip_horizontal',
-                              flipHorizontal ? 1 : 0
-                            )}
+                            onCheckedChange={() =>
+                              handleSetHardwareInfo(
+                                'flip_horizontal',
+                                flipHorizontal ? 1 : 0
+                              )
+                            }
                           />
                         </div>
                         <Separator />
-                        <div className="flex justify-between">
+                        <div className='flex justify-between'>
                           <Label>
                             {i18n._('sys.hardware_management.flip_vertical')}
                           </Label>
                           <Switch
                             checked={flipVertical}
-                            onCheckedChange={() => handleSetHardwareInfo(
-                              'flip_vertical',
-                              flipVertical ? 1 : 0
-                            )}
+                            onCheckedChange={() =>
+                              handleSetHardwareInfo(
+                                'flip_vertical',
+                                flipVertical ? 1 : 0
+                              )
+                            }
                           />
                         </div>
                         <Separator />
-                        <div className="flex justify-between gap-4 items-center">
-                          <div className="flex min-w-0 flex-1 items-center gap-2">
-                            <Label className="shrink-0">{i18n._('sys.hardware_management.isp_mode')}</Label>
+                        <div className='flex justify-between gap-4 items-center'>
+                          <div className='flex min-w-0 flex-1 items-center gap-2'>
+                            <Label className='shrink-0'>
+                              {i18n._('sys.hardware_management.isp_mode')}
+                            </Label>
                             <Tooltip mbEnhance>
                               <TooltipTrigger>
-                                <div className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500">
-                                  <SvgIcon className="h-4 w-4 text-gray-500" icon="info" />
+                                <div className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500'>
+                                  <SvgIcon
+                                    className='h-4 w-4 text-gray-500'
+                                    icon='info'
+                                  />
                                 </div>
                               </TooltipTrigger>
-                              <TooltipContent className="max-w-80 text-pretty">
+                              <TooltipContent className='max-w-80 text-pretty'>
                                 <div>
-                                  <p>{i18n._('sys.hardware_management.camera_config_reboot_hint')}</p>
+                                  <p>
+                                    {i18n._(
+                                      'sys.hardware_management.camera_config_reboot_hint'
+                                    )}
+                                  </p>
                                 </div>
                               </TooltipContent>
                             </Tooltip>
                           </div>
                           <Select
                             value={String(ispMode)}
-                            onValueChange={async (v) => {
+                            onValueChange={async v => {
                               const next = Number(v);
                               setIspMode(next);
                               try {
-                                await setHardwareInfoReq(buildImageConfigRequest({ isp_mode: next }));
+                                await setHardwareInfoReq(
+                                  buildImageConfigRequest({ isp_mode: next })
+                                );
+                                toast.warning(
+                                  i18n._(
+                                    'sys.hardware_management.camera_config_reboot_hint'
+                                  )
+                                );
                               } catch (error) {
                                 console.error(error);
                               }
                             }}
                           >
-                            <SelectTrigger className="w-44 border-0 shadow-none focus-visible:ring-0">
+                            <SelectTrigger className='w-44 border-0 shadow-none focus-visible:ring-0'>
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="0">{i18n._('sys.hardware_management.isp_mode_outdoor')}</SelectItem>
-                              <SelectItem value="1">{i18n._('sys.hardware_management.isp_mode_indoor')}</SelectItem>
-                              <SelectItem value="255">{i18n._('sys.hardware_management.isp_mode_custom')}</SelectItem>
+                              <SelectItem value='0'>
+                                {i18n._(
+                                  'sys.hardware_management.isp_mode_outdoor'
+                                )}
+                              </SelectItem>
+                              <SelectItem value='1'>
+                                {i18n._(
+                                  'sys.hardware_management.isp_mode_indoor'
+                                )}
+                              </SelectItem>
+                              <SelectItem value='255'>
+                                {i18n._(
+                                  'sys.hardware_management.isp_mode_custom'
+                                )}
+                              </SelectItem>
                             </SelectContent>
                           </Select>
                         </div>
                         {ispMode === ISP_MODE_CUSTOM && (
                           <>
                             <Separator />
-                            <div className="flex flex-wrap gap-2 justify-end">
+                            <div className='flex flex-wrap gap-2 justify-end'>
                               <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
+                                type='button'
+                                variant='outline'
+                                size='sm'
                                 onClick={async () => {
                                   try {
-                                    const res = (await getIspProfileExportReq()) as unknown as { data?: unknown };
-                                    const payload = (res as { data?: unknown })?.data ?? res;
-                                    const text = typeof payload === 'string'
-                                      ? payload
-                                      : JSON.stringify(payload, null, 2);
-                                    await downloadFile(text, 'isp_iq_profile.json');
-                                    toast.success(i18n._('sys.hardware_management.isp_profile_export_ok'));
+                                    const res =
+                                      (await getIspProfileExportReq()) as unknown as {
+                                        data?: unknown;
+                                      };
+                                    const payload =
+                                      (res as { data?: unknown })?.data ?? res;
+                                    const text =
+                                      typeof payload === 'string'
+                                        ? payload
+                                        : JSON.stringify(payload, null, 2);
+                                    await downloadFile(
+                                      text,
+                                      'isp_iq_profile.json'
+                                    );
+                                    toast.success(
+                                      i18n._(
+                                        'sys.hardware_management.isp_profile_export_ok'
+                                      )
+                                    );
                                   } catch (error) {
                                     console.error(error);
                                     toast.error('Export failed');
                                   }
                                 }}
                               >
-                                {i18n._('sys.hardware_management.isp_profile_export')}
+                                {i18n._(
+                                  'sys.hardware_management.isp_profile_export'
+                                )}
                               </Button>
                               <Button
-                                type="button"
-                                variant="outline"
-                                size="sm"
-                                onClick={() => ispImportInputRef.current?.click()}
+                                type='button'
+                                variant='outline'
+                                size='sm'
+                                onClick={() =>
+                                  ispImportInputRef.current?.click()
+                                }
                               >
-                                {i18n._('sys.hardware_management.isp_profile_import')}
+                                {i18n._(
+                                  'sys.hardware_management.isp_profile_import'
+                                )}
                               </Button>
                               <input
                                 ref={ispImportInputRef}
-                                type="file"
-                                accept="application/json,.json"
-                                className="hidden"
-                                onChange={async (ev) => {
+                                type='file'
+                                accept='application/json,.json'
+                                className='hidden'
+                                onChange={async ev => {
                                   const inputEl = ev.target as HTMLInputElement;
                                   const file = inputEl.files?.[0];
                                   inputEl.value = '';
                                   if (!file) return;
                                   try {
                                     const text = await file.text();
-                                    const json = JSON.parse(text) as Record<string, unknown>;
+                                    const json = JSON.parse(text) as Record<
+                                      string,
+                                      unknown
+                                    >;
                                     await postIspProfileImportReq(json);
-                                    toast.success(i18n._('sys.hardware_management.isp_profile_import_ok'));
+                                    toast.success(
+                                      i18n._(
+                                        'sys.hardware_management.isp_profile_import_ok'
+                                      )
+                                    );
                                   } catch (error) {
                                     console.error(error);
                                     toast.error('Import failed');
@@ -487,21 +562,26 @@ export default function Graphics() {
                   </div>
                   <Separator />
                   {/* Capture configuration (fast capture) */}
-                  <div className="flex flex-col gap-2">
+                  <div className='flex flex-col gap-2'>
                     <button
-                      type="button"
-                      className="flex w-full items-center justify-between text-left"
-                      onClick={() => setCaptureSectionOpen((o) => !o)}
+                      type='button'
+                      className='flex w-full items-center justify-between text-left'
+                      onClick={() => setCaptureSectionOpen(o => !o)}
                     >
-                      <div className="flex items-center gap-2">
-                        <Label>{i18n._('sys.hardware_management.capture_config')}</Label>
+                      <div className='flex items-center gap-2'>
+                        <Label>
+                          {i18n._('sys.hardware_management.capture_config')}
+                        </Label>
                         <Tooltip mbEnhance>
                           <TooltipTrigger>
-                            <div className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500">
-                              <SvgIcon className="h-4 w-4 text-gray-500" icon="info" />
+                            <div className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500'>
+                              <SvgIcon
+                                className='h-4 w-4 text-gray-500'
+                                icon='info'
+                              />
                             </div>
                           </TooltipTrigger>
-                          <TooltipContent className="max-w-80 text-pretty">
+                          <TooltipContent className='max-w-80 text-pretty'>
                             <div>
                               <p>
                                 {i18n._(
@@ -512,9 +592,9 @@ export default function Graphics() {
                           </TooltipContent>
                         </Tooltip>
                       </div>
-                      <span className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500">
+                      <span className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500'>
                         <SvgIcon
-                          icon="right"
+                          icon='right'
                           className={`h-4 w-4 transition-transform duration-200 ${
                             captureSectionOpen ? 'rotate-90' : 'rotate-0'
                           }`}
@@ -522,66 +602,83 @@ export default function Graphics() {
                       </span>
                     </button>
                     {captureSectionOpen && (
-                      <div className="border border-gray-200 border-solid p-4 rounded-md mt-2 flex flex-col gap-2">
-                        <div className="flex justify-between gap-4 items-center">
+                      <div className='border border-gray-200 border-solid p-4 rounded-md mt-2 flex flex-col gap-2'>
+                        <div className='flex justify-between gap-4 items-center'>
                           <Label>
-                            {i18n._('sys.hardware_management.fast_capture_skip_frames')}
+                            {i18n._(
+                              'sys.hardware_management.fast_capture_skip_frames'
+                            )}
                           </Label>
                           <Input
-                            className="w-24 text-right"
-                            type="number"
+                            className='w-24 text-right'
+                            type='number'
                             min={0}
                             max={300}
                             value={fastSkipFrames}
-                            onChange={(e) => {
-                              const raw = parseInt((e.target as HTMLInputElement).value || '0', 10);
+                            onChange={e => {
+                              const raw = parseInt(
+                                (e.target as HTMLInputElement).value || '0',
+                                10
+                              );
                               handleFastCaptureChange('fast_skip_frames', raw);
                               // set input value to input element
-                              (e.target as HTMLInputElement).value = String(fastSkipFrames);
+                              (e.target as HTMLInputElement).value =
+                                String(fastSkipFrames);
                             }}
-                            onBlur={(e) => {
-                              const raw = parseInt((e.target as HTMLInputElement).value || '0', 10);
+                            onBlur={e => {
+                              const raw = parseInt(
+                                (e.target as HTMLInputElement).value || '0',
+                                10
+                              );
                               postFastCapture('fast_skip_frames', raw);
                               // set input value to input element
-                              (e.target as HTMLInputElement).value = String(fastSkipFrames);
+                              (e.target as HTMLInputElement).value =
+                                String(fastSkipFrames);
                             }}
                           />
                         </div>
                         <Separator />
-                        <div className="flex justify-between gap-4 items-center">
+                        <div className='flex justify-between gap-4 items-center'>
                           <Label>
-                            {i18n._('sys.hardware_management.fast_capture_resolution')}
+                            {i18n._(
+                              'sys.hardware_management.fast_capture_resolution'
+                            )}
                           </Label>
                           <Select
                             value={String(fastResolution)}
-                            onValueChange={(value) => {
+                            onValueChange={value => {
                               const v = Number(value || 0);
                               handleSetHardwareInfo('fast_resolution', v);
                             }}
                           >
-                            <SelectTrigger className="border-0 shadow-none focus-visible:ring-0 focus-visible:border-transparent w-32">
+                            <SelectTrigger className='border-0 shadow-none focus-visible:ring-0 focus-visible:border-transparent w-32'>
                               <SelectValue />
                             </SelectTrigger>
                             <SelectContent>
-                              <SelectItem value="0">1280x720</SelectItem>
-                              <SelectItem value="1">1920x1080</SelectItem>
-                              <SelectItem value="2">2688x1520</SelectItem>
+                              <SelectItem value='0'>1280x720</SelectItem>
+                              <SelectItem value='1'>1920x1080</SelectItem>
+                              <SelectItem value='2'>2688x1520</SelectItem>
                             </SelectContent>
                           </Select>
                         </div>
                         <Separator />
-                        <div className="flex justify-between gap-4 items-center">
-                          <div className="flex min-w-0 flex-1 items-center gap-2">
-                            <Label className="shrink-0">
-                              {i18n._('sys.hardware_management.fast_capture_jpeg_quality')}
+                        <div className='flex justify-between gap-4 items-center'>
+                          <div className='flex min-w-0 flex-1 items-center gap-2'>
+                            <Label className='shrink-0'>
+                              {i18n._(
+                                'sys.hardware_management.fast_capture_jpeg_quality'
+                              )}
                             </Label>
                             <Tooltip mbEnhance>
                               <TooltipTrigger>
-                                <div className="inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500">
-                                  <SvgIcon className="h-4 w-4 text-gray-500" icon="info" />
+                                <div className='inline-flex h-4 w-4 shrink-0 items-center justify-center text-gray-500'>
+                                  <SvgIcon
+                                    className='h-4 w-4 text-gray-500'
+                                    icon='info'
+                                  />
                                 </div>
                               </TooltipTrigger>
-                              <TooltipContent className="max-w-80 text-pretty">
+                              <TooltipContent className='max-w-80 text-pretty'>
                                 <div>
                                   <p>
                                     {i18n._(
@@ -593,22 +690,30 @@ export default function Graphics() {
                             </Tooltip>
                           </div>
                           <Input
-                            className="w-24 text-right"
-                            type="number"
+                            className='w-24 text-right'
+                            type='number'
                             min={1}
                             max={100}
                             value={fastJpegQuality}
-                            onChange={(e) => {
-                              const raw = parseInt((e.target as HTMLInputElement).value || '0', 10);
+                            onChange={e => {
+                              const raw = parseInt(
+                                (e.target as HTMLInputElement).value || '0',
+                                10
+                              );
                               handleFastCaptureChange('fast_jpeg_quality', raw);
                               // set input value to input element
-                              (e.target as HTMLInputElement).value = String(fastJpegQuality); 
+                              (e.target as HTMLInputElement).value =
+                                String(fastJpegQuality);
                             }}
-                            onBlur={(e) => {
-                              const raw = parseInt((e.target as HTMLInputElement).value || '0', 10);
+                            onBlur={e => {
+                              const raw = parseInt(
+                                (e.target as HTMLInputElement).value || '0',
+                                10
+                              );
                               postFastCapture('fast_jpeg_quality', raw);
                               // set input value to input element
-                              (e.target as HTMLInputElement).value = String(fastJpegQuality);
+                              (e.target as HTMLInputElement).value =
+                                String(fastJpegQuality);
                             }}
                           />
                         </div>
@@ -914,161 +1019,243 @@ export default function Graphics() {
       )}
       {/* LuxRef configuration dialog */}
       <Dialog open={luxRefDialogOpen} onOpenChange={setLuxRefDialogOpen}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className='max-w-3xl'>
           <DialogHeader>
-            <DialogTitle>{i18n._('sys.hardware_management.lux_ref_title') ?? 'Lux Calibration Setup'}</DialogTitle>
+            <DialogTitle>
+              {i18n._('sys.hardware_management.lux_ref_title') ??
+                'Lux Calibration Setup'}
+            </DialogTitle>
           </DialogHeader>
-          <div className="mt-8 space-y-6">
+          <div className='mt-8 space-y-6'>
             {/* Sensor calibration factor */}
-            <div className="space-y-2">
-              <Label>{i18n._('sys.hardware_management.lux_ref_calib_factor') ?? 'Sensor calibration factor'}</Label>
+            <div className='space-y-2'>
+              <Label>
+                {i18n._('sys.hardware_management.lux_ref_calib_factor') ??
+                  'Sensor calibration factor'}
+              </Label>
               <Input
-                className="max-w-xs"
-                type="number"
+                className='max-w-xs'
+                type='number'
                 step={0.001}
                 value={luxRefForm.calibFactor}
-                onChange={(e) => setLuxRefForm((prev) => ({
+                onChange={e =>
+                  setLuxRefForm(prev => ({
                     ...prev,
-                    calibFactor: Number((e.target as HTMLInputElement).value || 0),
-                  }))}
+                    calibFactor: Number(
+                      (e.target as HTMLInputElement).value || 0
+                    ),
+                  }))
+                }
               />
             </div>
             {/* High lux conditions */}
-            <div className="space-y-3">
-              <Label className="font-semibold">
-                {i18n._('sys.hardware_management.lux_ref_high_title') ?? 'High lux conditions'}
+            <div className='space-y-3'>
+              <Label className='font-semibold'>
+                {i18n._('sys.hardware_management.lux_ref_high_title') ??
+                  'High lux conditions'}
               </Label>
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_hl_ref') ?? 'High lux reference (lx)'}</Label>
+              <div className='grid gap-4 md:grid-cols-3'>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_hl_ref') ??
+                      'High lux reference (lx)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.hlRef}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        hlRef: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        hlRef: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_hl_expo1') ?? '1st ref exposure time (µs)'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_hl_expo1') ??
+                      '1st ref exposure time (µs)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.hlExpo1}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        hlExpo1: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        hlExpo1: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_hl_lum1') ?? '1st ref luminance'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_hl_lum1') ??
+                      '1st ref luminance'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.hlLum1}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        hlLum1: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        hlLum1: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_hl_expo2') ?? '2nd ref exposure time (µs)'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_hl_expo2') ??
+                      '2nd ref exposure time (µs)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.hlExpo2}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        hlExpo2: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        hlExpo2: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_hl_lum2') ?? '2nd ref luminance'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_hl_lum2') ??
+                      '2nd ref luminance'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.hlLum2}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        hlLum2: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        hlLum2: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
               </div>
             </div>
             {/* Low lux conditions */}
-            <div className="space-y-3">
-              <Label className="font-semibold">
-                {i18n._('sys.hardware_management.lux_ref_low_title') ?? 'Low lux conditions'}
+            <div className='space-y-3'>
+              <Label className='font-semibold'>
+                {i18n._('sys.hardware_management.lux_ref_low_title') ??
+                  'Low lux conditions'}
               </Label>
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_ll_ref') ?? 'Low lux reference (lx)'}</Label>
+              <div className='grid gap-4 md:grid-cols-3'>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_ll_ref') ??
+                      'Low lux reference (lx)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.llRef}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        llRef: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        llRef: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_ll_expo1') ?? '1st ref exposure time (µs)'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_ll_expo1') ??
+                      '1st ref exposure time (µs)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.llExpo1}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        llExpo1: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        llExpo1: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_ll_lum1') ?? '1st ref luminance'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_ll_lum1') ??
+                      '1st ref luminance'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.llLum1}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        llLum1: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        llLum1: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_ll_expo2') ?? '2nd ref exposure time (µs)'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_ll_expo2') ??
+                      '2nd ref exposure time (µs)'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.llExpo2}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        llExpo2: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        llExpo2: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
-                <div className="space-y-1">
-                  <Label>{i18n._('sys.hardware_management.lux_ref_ll_lum2') ?? '2nd ref luminance'}</Label>
+                <div className='space-y-1'>
+                  <Label>
+                    {i18n._('sys.hardware_management.lux_ref_ll_lum2') ??
+                      '2nd ref luminance'}
+                  </Label>
                   <Input
-                    type="number"
+                    type='number'
                     value={luxRefForm.llLum2}
-                    onChange={(e) => setLuxRefForm((prev) => ({
+                    onChange={e =>
+                      setLuxRefForm(prev => ({
                         ...prev,
-                        llLum2: Number((e.target as HTMLInputElement).value || 0),
-                      }))}
+                        llLum2: Number(
+                          (e.target as HTMLInputElement).value || 0
+                        ),
+                      }))
+                    }
                   />
                 </div>
               </div>
             </div>
           </div>
-          <DialogFooter className="mt-6">
+          <DialogFooter className='mt-6'>
             <Button
-              variant="outline"
+              variant='outline'
               onClick={() => setLuxRefDialogOpen(false)}
             >
               {i18n._('common.cancel') ?? 'Cancel'}
             </Button>
             <Button
-              variant="primary"
+              variant='primary'
               onClick={() => {
                 // TODO: wire to /api/v1/isp/lux_ref save
                 setLuxRefDialogOpen(false);

--- a/Web/src/services/api/deviceTool.ts
+++ b/Web/src/services/api/deviceTool.ts
@@ -132,6 +132,11 @@ const deviceTool = {
   getRtspClientsReq: () => request.get('/api/v1/apps/rtsp/clients'),
   kickRtspClientReq: (id: string) => request.delete(`/api/v1/apps/rtsp/clients/${id}`),
 
+  getStreamTabPrefReq: () =>
+    request.get('/api/v1/device/preference/stream_tab'),
+  setStreamTabPrefReq: (data: { stream_tab: string }) =>
+    request.post('/api/v1/device/preference/stream_tab', data),
+
   // // PIR
   // getPirConfigReq: () => request.get('/api/v1/work-mode/triggers'),
   // setPirConfigReq: (data: PirConfigReq) => request.post('/api/v1/work-mode/triggers', data),


### PR DESCRIPTION
- Add GET/POST /api/v1/device/preference/stream_tab API to persist user's preferred stream tab (rtmp/rtsp) across page reloads
- Fix capture upload result: webhook success now correctly sets upload_result=OK and MQTT puback failure only marks error when no other upload path succeeded
- Update graphics management and RTMP config frontend pages