### PR TITLE
fix(video): resolve black preview after model upload by invalidating …

### DIFF
--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -19,6 +19,7 @@
 #include "json_config_mgr.h"
 #include "video_camera_node.h"
 #include "device_service.h"
+#include "Services/Video/video_stream_hub.h"
 
 /* ==================== AI Service Context ==================== */
 
@@ -71,6 +72,8 @@ static aicam_result_t ai_create_camera_pipeline_nodes(const ai_service_config_t 
 static aicam_result_t ai_create_ai_pipeline_nodes(const ai_service_config_t *config);
 static aicam_result_t ai_connect_camera_pipeline_nodes(void);
 static aicam_result_t ai_connect_ai_pipeline_nodes(void);
+
+static aicam_result_t ai_reload_model_restart_pipeline(void);
 
 static aicam_result_t ai_service_draw_callback(uint8_t *frame_buffer, 
                                              uint32_t width, 
@@ -385,7 +388,15 @@ aicam_result_t ai_pipeline_stop(void)
     }
     
     LOG_SVC_INFO("AI pipelines stopped successfully");
-    
+
+    /* Encoder session is torn down with the camera pipeline; drop the stale
+     * SPS/PPS cache so the next pipeline start re-extracts fresh params.
+     * Otherwise the MSE player is fed stale SPS/PPS and the preview stays
+     * black after a model reload / pipeline restart. */
+    if (video_hub_is_initialized()) {
+        video_hub_invalidate_sps_pps();
+    }
+
     return result;
 }
 
@@ -1041,6 +1052,7 @@ aicam_result_t ai_reload_model(void)
     if (result != AICAM_OK) {
         LOG_SVC_ERROR("Failed to reload AI model: %d", result);
         device_service_camera_start();
+        ai_reload_model_restart_pipeline();
         return result;
     }
 
@@ -1051,6 +1063,17 @@ aicam_result_t ai_reload_model(void)
         return result;
     }
 
+    //Restart pipelines when a preview subscriber is already attached (e.g. a
+    //direct /model/reload call with preview active) so frame production
+    //resumes and the still-connected subscriber receives the encoder's fresh
+    //IDR + SPS/PPS immediately. When preview was stopped first (the web
+    //feature-debug upload flow leaves no subscribers here), leave the pipeline
+    //stopped: the subsequent /preview/start re-subscribes and the Hub
+    //auto-starts the pipeline, which captures the encoder's first IDR instead
+    //of dropping it (an unconditional start here would discard that IDR while
+    //there are zero subscribers, delaying preview recovery by one GOP).
+    ai_reload_model_restart_pipeline();
+
     //deint draw service
     // result = ai_draw_service_deinit();
     // if (result != AICAM_OK) {
@@ -1059,6 +1082,21 @@ aicam_result_t ai_reload_model(void)
     // }
 
     return AICAM_OK;
+}
+
+/* Restart the AI pipelines after a model reload, but only when the Video Hub
+ * currently has subscribers. See ai_reload_model() for the rationale. */
+static aicam_result_t ai_reload_model_restart_pipeline(void)
+{
+    if (!video_hub_is_initialized() || !video_hub_has_subscribers()) {
+        return AICAM_OK;
+    }
+
+    aicam_result_t result = ai_pipeline_start();
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to restart AI pipelines after model reload: %d", result);
+    }
+    return result;
 }
 
 /* ==================== AI Statistics Functions ==================== */

--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -1051,8 +1051,9 @@ aicam_result_t ai_reload_model(void)
     result = video_ai_node_reload_model(g_ai_service.ai_node);
     if (result != AICAM_OK) {
         LOG_SVC_ERROR("Failed to reload AI model: %d", result);
-        device_service_camera_start();
-        ai_reload_model_restart_pipeline();
+        if (device_service_camera_start() == AICAM_OK) {
+            ai_reload_model_restart_pipeline();
+        }
         return result;
     }
 

--- a/Custom/Services/Video/video_stream_hub.c
+++ b/Custom/Services/Video/video_stream_hub.c
@@ -367,11 +367,40 @@ aicam_result_t video_hub_get_sps_pps(video_hub_sps_pps_t *sps_pps)
     if (!sps_pps || !g_hub.sps_pps_valid) {
         return AICAM_ERROR_UNAVAILABLE;
     }
-    
+
     sps_pps->sps_data = g_hub.sps_data;
     sps_pps->sps_size = g_hub.sps_size;
     sps_pps->pps_data = g_hub.pps_data;
     sps_pps->pps_size = g_hub.pps_size;
+    return AICAM_OK;
+}
+
+aicam_result_t video_hub_invalidate_sps_pps(void)
+{
+    if (!g_hub.initialized) {
+        return AICAM_ERROR_NOT_INITIALIZED;
+    }
+
+    osMutexAcquire(g_hub.mutex, osWaitForever);
+
+    /* Drop the cached SPS/PPS so the next injected keyframe re-extracts the
+     * encoder's current SPS/PPS (the encoder session may have been rebuilt
+     * after a model reload / pipeline restart). */
+    if (g_hub.sps_data) { hal_mem_free(g_hub.sps_data); g_hub.sps_data = NULL; }
+    if (g_hub.pps_data) { hal_mem_free(g_hub.pps_data); g_hub.pps_data = NULL; }
+    g_hub.sps_size = 0;
+    g_hub.pps_size = 0;
+    g_hub.sps_pps_valid = AICAM_FALSE;
+
+    /* Allow the freshly extracted SPS/PPS to be re-delivered to subscribers
+     * that already received the now-stale copy. */
+    for (uint32_t i = 0; i < VIDEO_HUB_MAX_SUBSCRIBERS; i++) {
+        g_hub.subscribers[i].sps_pps_sent = AICAM_FALSE;
+    }
+
+    osMutexRelease(g_hub.mutex);
+
+    LOG_SVC_INFO("Hub: SPS/PPS cache invalidated (encoder session reset)");
     return AICAM_OK;
 }
 

--- a/Custom/Services/Video/video_stream_hub.c
+++ b/Custom/Services/Video/video_stream_hub.c
@@ -364,7 +364,22 @@ aicam_result_t video_hub_inject_sps_pps(const uint8_t *sps, uint32_t sps_size,
 
 aicam_result_t video_hub_get_sps_pps(video_hub_sps_pps_t *sps_pps)
 {
-    if (!sps_pps || !g_hub.sps_pps_valid) {
+    if (!sps_pps) {
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+
+    if (!g_hub.initialized) {
+        return AICAM_ERROR_NOT_INITIALIZED;
+    }
+
+    /* The cache can be freed at runtime by video_hub_invalidate_sps_pps()
+     * (called from ai_pipeline_stop on model reload). Take the mutex so the
+     * valid-flag check and the pointer/size reads happen atomically against
+     * a concurrent invalidation, avoiding a use-after-free of sps_data/pps_data. */
+    osMutexAcquire(g_hub.mutex, osWaitForever);
+
+    if (!g_hub.sps_pps_valid) {
+        osMutexRelease(g_hub.mutex);
         return AICAM_ERROR_UNAVAILABLE;
     }
 
@@ -372,6 +387,8 @@ aicam_result_t video_hub_get_sps_pps(video_hub_sps_pps_t *sps_pps)
     sps_pps->sps_size = g_hub.sps_size;
     sps_pps->pps_data = g_hub.pps_data;
     sps_pps->pps_size = g_hub.pps_size;
+
+    osMutexRelease(g_hub.mutex);
     return AICAM_OK;
 }
 

--- a/Custom/Services/Video/video_stream_hub.h
+++ b/Custom/Services/Video/video_stream_hub.h
@@ -131,6 +131,15 @@ aicam_result_t video_hub_inject_sps_pps(const uint8_t *sps, uint32_t sps_size,
  */
 aicam_result_t video_hub_get_sps_pps(video_hub_sps_pps_t *sps_pps);
 
+/**
+ * @brief Invalidate cached SPS/PPS and reset per-subscriber send flags
+ * @details Call when the encoder session is torn down (e.g. pipeline stop /
+ *          model reload) so the next keyframe re-extracts fresh SPS/PPS and
+ *          re-delivers them to subscribers. Stale SPS/PPS causes the MSE
+ *          decoder to reject the new stream (black preview).
+ */
+aicam_result_t video_hub_invalidate_sps_pps(void);
+
 /* ==================== Status API ==================== */
 
 aicam_bool_t video_hub_is_initialized(void);


### PR DESCRIPTION
…stale SPS/PPS cache

Root cause: Video Hub cached SPS/PPS only once (sps_pps_valid set TRUE, never reset). When a model reload rebuilds the encoder session, the Hub kept serving stale SPS/PPS to the reconnecting MSE player, causing a codec mismatch and permanent black preview.

Fix 1: Add video_hub_invalidate_sps_pps() and call it in ai_pipeline_stop() so the next keyframe re-extracts fresh SPS/PPS from the rebuilt encoder session and re-delivers them to subscribers.

Fix 2: ai_reload_model() now conditionally restarts the AI pipeline (only when video_hub_has_subscribers()) to resume frame production when preview is active, while leaving the frontend upload flow (no subscribers) to recover via preview/start's Hub auto-start, which captures the encoder's first IDR instead of dropping it.