### PR TITLE
Add SPE result handling and an overlay_results gate for clean encoded output

### DIFF
--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -61,6 +61,7 @@
  #define NVS_KEY_AI_PIPE_HEIGHT      "ai_pipe_height"
  #define NVS_KEY_CONFIDENCE          "confidence"
  #define NVS_KEY_NMS_THRESHOLD       "nms_thresh"
+ #define NVS_KEY_OVERLAY_RESULTS     "overlay_results"
  
  // Power mode configuration key names
  #define NVS_KEY_POWER_CURRENT_MODE  "power_cur_mode"

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -107,6 +107,7 @@ static void parse_ai_debug(cJSON *json, ai_debug_config_t *cfg)
     json_get_bool(json, "ai_1_active", &cfg->ai_1_active);
     json_get_uint32(json, "confidence_threshold", &cfg->confidence_threshold);
     json_get_uint32(json, "nms_threshold", &cfg->nms_threshold);
+    json_get_bool(json, "overlay_results", &cfg->overlay_results);
 }
 
 static void parse_power_mode(cJSON *json, power_mode_config_t *cfg)
@@ -658,6 +659,7 @@ static cJSON *serialize_ai_debug(const ai_debug_config_t *cfg)
     cJSON_AddBoolToObject(json, "ai_1_active", cfg->ai_1_active);
     cJSON_AddNumberToObject(json, "confidence_threshold", cfg->confidence_threshold);
     cJSON_AddNumberToObject(json, "nms_threshold", cfg->nms_threshold);
+    cJSON_AddBoolToObject(json, "overlay_results", cfg->overlay_results);
     return json;
 }
 

--- a/Custom/Core/System/json_config_mgr.c
+++ b/Custom/Core/System/json_config_mgr.c
@@ -35,7 +35,8 @@
          .ai_enabled = AICAM_FALSE,
          .ai_1_active = AICAM_FALSE,
          .confidence_threshold = 50,
-         .nms_threshold = 50
+         .nms_threshold = 50,
+         .overlay_results = AICAM_TRUE
      },
      
      .power_mode_config = {
@@ -799,6 +800,20 @@
  uint32_t json_config_get_nms_threshold(void)
  {
      return g_json_config_ctx.current_config.ai_debug.nms_threshold;
+ }
+
+ aicam_result_t json_config_set_overlay_results(aicam_bool_t overlay_results)
+ {
+     g_json_config_ctx.current_config.ai_debug.overlay_results = overlay_results;
+
+     // update to NVS
+     json_config_nvs_write_bool(NVS_KEY_OVERLAY_RESULTS, overlay_results);
+     return AICAM_OK;
+ }
+
+ aicam_bool_t json_config_get_overlay_results(void)
+ {
+     return g_json_config_ctx.current_config.ai_debug.overlay_results;
  }
 
  /*=================== Work Mode Configuration API Implementation ====================*/

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -31,6 +31,7 @@
      aicam_bool_t ai_1_active;      // AI_1 active switch
      uint32_t confidence_threshold;             // Confidence threshold 0-100
      uint32_t nms_threshold;                    // NMS threshold 0-100
+     aicam_bool_t overlay_results;  // Draw AI results onto encoded frames
  } ai_debug_config_t;
  
 typedef struct {
@@ -813,8 +814,21 @@ uint32_t json_config_get_confidence_threshold(void);
 /**
  * @brief Get NMS threshold
  * @return NMS threshold
- */ 
+ */
 uint32_t json_config_get_nms_threshold(void);
+
+/**
+ * @brief Set AI overlay results flag
+ * @param overlay_results Draw AI results onto encoded frames
+ * @return aicam_result_t Operation result
+ */
+aicam_result_t json_config_set_overlay_results(aicam_bool_t overlay_results);
+
+/**
+ * @brief Get AI overlay results flag
+ * @return AI overlay results flag
+ */
+aicam_bool_t json_config_get_overlay_results(void);
 
 
 /**
@@ -984,6 +998,7 @@ aicam_result_t json_config_delete_webhook_ca_cert(void);
 #define JSON_CONFIG_GET_AI_1_ACTIVE(config)    ((config)->ai_debug.ai_1_active)
 #define JSON_CONFIG_GET_CONFIDENCE(config)     ((config)->ai_debug.confidence_threshold)
 #define JSON_CONFIG_GET_NMS_THRESHOLD(config)  ((config)->ai_debug.nms_threshold)
+#define JSON_CONFIG_GET_OVERLAY_RESULTS(config) ((config)->ai_debug.overlay_results)
 
 // Macros for quick access to power mode configuration
 #define JSON_CONFIG_GET_POWER_MODE(config)     ((config)->power_mode_config.current_mode)

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -62,6 +62,10 @@ aicam_result_t json_config_save_ai_debug_config_to_nvs(const ai_debug_config_t *
     if (result != AICAM_OK)
         LOG_CORE_ERROR("Failed to save nms threshold to NVS");
 
+    result = json_config_nvs_write_bool(NVS_KEY_OVERLAY_RESULTS, config->overlay_results);
+    if (result != AICAM_OK)
+        LOG_CORE_ERROR("Failed to save overlay results to NVS");
+
     LOG_CORE_INFO("AI debug configuration saved to NVS successfully");
     return result;
 }
@@ -1441,6 +1445,12 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         config->ai_debug.nms_threshold = temp_uint32;
     else
         json_config_nvs_write_uint32(NVS_KEY_NMS_THRESHOLD, config->ai_debug.nms_threshold);
+
+    result = json_config_nvs_read_bool(NVS_KEY_OVERLAY_RESULTS, &temp_bool);
+    if (result == AICAM_OK)
+        config->ai_debug.overlay_results = temp_bool;
+    else
+        json_config_nvs_write_bool(NVS_KEY_OVERLAY_RESULTS, config->ai_debug.overlay_results);
 
     // Load power mode configuration
     result = json_config_nvs_read_uint32(NVS_KEY_POWER_CURRENT_MODE, &temp_uint32);

--- a/Custom/Core/Video/ai_draw_service.c
+++ b/Custom/Core/Video/ai_draw_service.c
@@ -24,6 +24,7 @@ static aicam_result_t ai_draw_deinit_fonts(void);
 static aicam_result_t ai_draw_setup_draw_device(void);
 static aicam_result_t ai_draw_configure_od_drawing(void);
 static aicam_result_t ai_draw_configure_mpe_drawing(void);
+static aicam_result_t ai_draw_configure_spe_drawing(void);
 static aicam_result_t ai_draw_configure_iseg_drawing(void);
 
 /* ==================== AI Drawing Service Implementation ==================== */
@@ -76,6 +77,14 @@ aicam_result_t ai_draw_service_init(const ai_draw_config_t *config)
         return result;
     }
 
+    // Configure SPE drawing
+    result = ai_draw_configure_spe_drawing();
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to configure SPE drawing: %d", result);
+        ai_draw_deinit_fonts();
+        return result;
+    }
+
     // Configure ISEG drawing
     result = ai_draw_configure_iseg_drawing();
     if (result != AICAM_OK) {
@@ -83,7 +92,7 @@ aicam_result_t ai_draw_service_init(const ai_draw_config_t *config)
         ai_draw_deinit_fonts();
         return result;
     }
-    
+
     g_ai_draw_service.initialized = AICAM_TRUE;
     
     LOG_SVC_INFO("AI draw service initialized successfully");
@@ -101,6 +110,9 @@ aicam_result_t ai_draw_service_deinit(void)
     
     // Deinitialize MPE drawing
     mpe_draw_deinit(&g_ai_draw_service.mpe_draw_conf);
+
+    // Deinitialize SPE drawing
+    spe_draw_deinit(&g_ai_draw_service.spe_draw_conf);
 
     // Deinitialize ISEG drawing
     iseg_draw_deinit(&g_ai_draw_service.iseg_draw_conf);
@@ -147,6 +159,12 @@ aicam_result_t ai_draw_results(uint8_t *fb,
         case PP_TYPE_MPE:
             if (result->mpe.nb_detect > 0) {
                 result_code = ai_draw_mpe_results(fb, fb_width, fb_height, &result->mpe);
+            }
+            break;
+
+        case PP_TYPE_SPE:
+            if (result->spe.nb_keypoints > 0) {
+                result_code = ai_draw_spe_results(fb, fb_width, fb_height, &result->spe);
             }
             break;
 
@@ -229,9 +247,39 @@ aicam_result_t ai_draw_mpe_results(uint8_t *fb,
     return AICAM_OK;
 }
 
-aicam_result_t ai_draw_single_od(uint8_t *fb, 
-                                 uint32_t fb_width, 
-                                 uint32_t fb_height, 
+aicam_result_t ai_draw_spe_results(uint8_t *fb,
+                                   uint32_t fb_width,
+                                   uint32_t fb_height,
+                                   const pp_spe_out_t *spe_result)
+{
+    if (!fb || !spe_result) {
+        LOG_SVC_ERROR("Invalid parameters for SPE draw results");
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+
+    if (!g_ai_draw_service.initialized) {
+        LOG_SVC_ERROR("AI draw service not initialized");
+        return AICAM_ERROR_NOT_INITIALIZED;
+    }
+
+    // Update drawing configuration with current frame buffer
+    g_ai_draw_service.spe_draw_conf.p_dst = fb;
+    g_ai_draw_service.spe_draw_conf.image_width = fb_width;
+    g_ai_draw_service.spe_draw_conf.image_height = fb_height;
+
+    // Draw the single pose instance
+    aicam_result_t result = spe_draw_result(&g_ai_draw_service.spe_draw_conf, spe_result);
+    if (result != 0) {
+        LOG_SVC_ERROR("Failed to draw SPE result: %d", result);
+        return AICAM_ERROR;
+    }
+
+    return AICAM_OK;
+}
+
+aicam_result_t ai_draw_single_od(uint8_t *fb,
+                                 uint32_t fb_width,
+                                 uint32_t fb_height,
                                  const od_detect_t *detection)
 {
     if (!fb || !detection) {
@@ -303,6 +351,7 @@ void ai_draw_get_default_config(ai_draw_config_t *config)
     config->dot_width = 4;
     config->od_color = COLOR_RED;
     config->mpe_color = COLOR_BLUE;
+    config->spe_color = COLOR_BLUE;
     config->iseg_color = COLOR_CYAN;
     config->iseg_mask_alpha = 102;
     config->iseg_mask_threshold = 128;
@@ -333,6 +382,12 @@ aicam_result_t ai_draw_set_config(const ai_draw_config_t *config)
     result = ai_draw_configure_mpe_drawing();
     if (result != AICAM_OK) {
         LOG_SVC_ERROR("Failed to reconfigure MPE drawing: %d", result);
+        return result;
+    }
+
+    result = ai_draw_configure_spe_drawing();
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to reconfigure SPE drawing: %d", result);
         return result;
     }
 
@@ -507,6 +562,29 @@ static aicam_result_t ai_draw_configure_mpe_drawing(void)
     }
     
     LOG_SVC_DEBUG("MPE drawing configured");
+
+    return AICAM_OK;
+}
+
+static aicam_result_t ai_draw_configure_spe_drawing(void)
+{
+    // Configure SPE drawing
+    g_ai_draw_service.spe_draw_conf.p_dst = NULL;  // Will be set during drawing
+    g_ai_draw_service.spe_draw_conf.color = g_ai_draw_service.config.spe_color;
+    g_ai_draw_service.spe_draw_conf.image_width = g_ai_draw_service.config.image_width;
+    g_ai_draw_service.spe_draw_conf.image_height = g_ai_draw_service.config.image_height;
+    g_ai_draw_service.spe_draw_conf.line_width = g_ai_draw_service.config.line_width;
+    g_ai_draw_service.spe_draw_conf.dot_width = g_ai_draw_service.config.dot_width;
+    g_ai_draw_service.spe_draw_conf.font = g_ai_draw_service.font_12;
+
+    // Initialize SPE drawing
+    aicam_result_t result = spe_draw_init(&g_ai_draw_service.spe_draw_conf);
+    if (result != 0) {
+        LOG_SVC_ERROR("Failed to initialize SPE drawing: %d", result);
+        return AICAM_ERROR;
+    }
+
+    LOG_SVC_DEBUG("SPE drawing configured");
 
     return AICAM_OK;
 }

--- a/Custom/Core/Video/ai_draw_service.h
+++ b/Custom/Core/Video/ai_draw_service.h
@@ -29,6 +29,7 @@ typedef struct {
     uint32_t dot_width;                    // Keypoint dot width
     uint32_t od_color;                     // Object detection box color
     uint32_t mpe_color;                    // MPE detection box color
+    uint32_t spe_color;                    // SPE keypoint color
     uint32_t iseg_color;                   // ISEG detection base color
     uint8_t  iseg_mask_alpha;              // ISEG mask overlay alpha (0-255)
     uint8_t  iseg_mask_threshold;         // ISEG mask pixel threshold (0-255)
@@ -43,6 +44,7 @@ typedef struct {
     aicam_bool_t initialized;              // Initialization status
     ai_draw_config_t config;               // Drawing configuration
     mpe_draw_conf_t mpe_draw_conf;         // MPE drawing configuration
+    spe_draw_conf_t spe_draw_conf;         // SPE drawing configuration
     od_draw_conf_t od_draw_conf;           // OD drawing configuration
     iseg_draw_conf_t iseg_draw_conf;       // ISEG drawing configuration
     DRAW_Font_t font_12;                   // 12pt font
@@ -99,10 +101,23 @@ aicam_result_t ai_draw_od_results(uint8_t *fb,
  * @param mpe_result MPE detection result
  * @return aicam_result_t Operation result
  */
-aicam_result_t ai_draw_mpe_results(uint8_t *fb, 
-                                   uint32_t fb_width, 
-                                   uint32_t fb_height, 
+aicam_result_t ai_draw_mpe_results(uint8_t *fb,
+                                   uint32_t fb_width,
+                                   uint32_t fb_height,
                                    const pp_mpe_out_t *mpe_result);
+
+/**
+ * @brief Draw SPE (Single-Person Pose Estimation) results
+ * @param fb Frame buffer pointer
+ * @param fb_width Frame buffer width
+ * @param fb_height Frame buffer height
+ * @param spe_result SPE detection result
+ * @return aicam_result_t Operation result
+ */
+aicam_result_t ai_draw_spe_results(uint8_t *fb,
+                                   uint32_t fb_width,
+                                   uint32_t fb_height,
+                                   const pp_spe_out_t *spe_result);
 
 /**
  * @brief Draw single object detection

--- a/Custom/Core/Video/video_ai_node.c
+++ b/Custom/Core/Video/video_ai_node.c
@@ -56,7 +56,7 @@ void video_ai_get_default_config(video_ai_config_t *config) {
     config->max_detections = 32;
     config->processing_interval = 1;  // Process every frame
     config->enabled = AICAM_TRUE;
-    config->overlay_results = AICAM_FALSE;
+    config->overlay_results = AICAM_TRUE;  // Overlay on by default (stock behavior)
     config->enable_drawing = AICAM_TRUE;
     
     // Initialize drawing configuration

--- a/Custom/Core/Video/video_camera_node.c
+++ b/Custom/Core/Video/video_camera_node.c
@@ -69,6 +69,7 @@ void video_camera_get_default_config(video_camera_config_t *config) {
     config->format = DCMIPP_PIXEL_PACKER_FORMAT_RGB565_1;
     config->bpp = 2;
     config->ai_enabled = AICAM_FALSE;
+    config->overlay_results = AICAM_TRUE;
 }
 
 video_node_t* video_camera_node_create(const char *name, const video_camera_config_t *config) {
@@ -138,9 +139,11 @@ aicam_result_t video_camera_node_set_config(video_node_t *node, const video_came
     data->config.format = config->format;
     data->config.bpp = config->bpp;
     data->config.ai_enabled = config->ai_enabled;
-    LOG_CORE_INFO("Camera node config updated: %dx%d@%dfps, format=%d, bpp=%d, ai_enabled=%d", 
-                  data->config.width, data->config.height, data->config.fps, 
-                  data->config.format, data->config.bpp, data->config.ai_enabled);
+    data->config.overlay_results = config->overlay_results;
+    LOG_CORE_INFO("Camera node config updated: %dx%d@%dfps, format=%d, bpp=%d, ai_enabled=%d, overlay_results=%d",
+                  data->config.width, data->config.height, data->config.fps,
+                  data->config.format, data->config.bpp, data->config.ai_enabled,
+                  data->config.overlay_results);
     
     // Restart camera if it was running
     // if (data->is_running) {
@@ -467,8 +470,9 @@ static aicam_result_t video_camera_capture_frame_zero_copy(video_camera_node_dat
     data->current_buffer = camera_buffer_with_frame_id.buffer;
     data->frame_id = camera_buffer_with_frame_id.frame_id;
 
-    //if ai enabled.draw ai result
-    if (data->config.ai_enabled == AICAM_TRUE && data->ai_draw_callback) {
+    //if ai enabled and overlay allowed, draw ai result onto the frame
+    if (data->config.ai_enabled == AICAM_TRUE && data->config.overlay_results == AICAM_TRUE &&
+        data->ai_draw_callback) {
         result = device_ioctl(data->camera_dev, CAM_CMD_LOCK_PIPE1_BUFFER, 
                             camera_buffer_with_frame_id.buffer, 0);
         if (result == AICAM_OK) {

--- a/Custom/Core/Video/video_camera_node.h
+++ b/Custom/Core/Video/video_camera_node.h
@@ -29,6 +29,7 @@ typedef struct {
     uint32_t format;                      // Pixel format
     uint32_t bpp;                         // Bytes per pixel
     uint32_t ai_enabled;                  // AI processing enabled
+    uint32_t overlay_results;             // Draw AI results onto captured frames
 } video_camera_config_t;
 
 /**

--- a/Custom/Hal/Quick_Bootstrap/quick_bootstrap.c
+++ b/Custom/Hal/Quick_Bootstrap/quick_bootstrap.c
@@ -702,6 +702,7 @@ static aicam_bool_t qb_ai_has_detections(const nn_result_t *r)
     if (!r->is_valid) return AICAM_FALSE;
     if (r->type == PP_TYPE_OD) return (r->od.nb_detect > 0) ? AICAM_TRUE : AICAM_FALSE;
     if (r->type == PP_TYPE_MPE) return (r->mpe.nb_detect > 0) ? AICAM_TRUE : AICAM_FALSE;
+    if (r->type == PP_TYPE_SPE) return (r->spe.nb_keypoints > 0) ? AICAM_TRUE : AICAM_FALSE;
     return AICAM_FALSE;
 }
 

--- a/Custom/Hal/ai_draw.c
+++ b/Custom/Hal/ai_draw.c
@@ -11,6 +11,7 @@
 #define COLOR_TRUNK COLOR_MAGENTA
 #define COLOR_LEGS COLOR_YELLOW
 #define MPE_YOLOV8_PP_CONF_THRESHOLD (0.6000000000f)
+#define SPE_MOVENET_PP_CONF_THRESHOLD (0.3000000000f)
 
 __attribute__((unused)) static const int bindings[][3] = {
   {15, 13, COLOR_LEGS},
@@ -606,6 +607,160 @@ int iseg_draw_result(iseg_draw_conf_t *iseg_conf, iseg_detect_t *result, uint32_
     print_param.x_pos = x0 + iseg_conf->line_width;
     print_param.y_pos = y0 + iseg_conf->line_width;
     device_ioctl(draw, DRAW_CMD_PRINTF, (uint8_t *)&print_param, sizeof(draw_printf_param_t));
+
+    return 0;
+}
+
+/* ==================== SPE Drawing ==================== */
+
+int spe_draw_init(spe_draw_conf_t *spe_conf)
+{
+    int ret;
+    if(spe_conf == NULL){
+        LOG_DRV_ERROR("spe_draw_init invalid param\r\n");
+        return -1;
+    }
+
+    device_t *draw = device_find_pattern(DRAW_DEVICE_NAME, DEV_TYPE_VIDEO);
+    if(draw == NULL){
+        return -1;
+    }
+    spe_conf->color = COLOR_YELLOW;
+    spe_conf->line_width = 2;
+    spe_conf->dot_width = 10;
+
+    draw_fontsetup_param_t font_param = {0};
+    /* set 16 font */
+    if(spe_conf->font.data){
+        hal_mem_free(spe_conf->font.data);
+        spe_conf->font.data = NULL;
+    }
+    font_param.p_font_in = &Font16;
+    font_param.p_font = &spe_conf->font;
+    ret = device_ioctl(draw, DRAW_CMD_FONT_SETUP, (uint8_t *)&font_param, sizeof(draw_fontsetup_param_t));
+    if(ret < 0){
+        LOG_DRV_ERROR("spe_draw_init failed\r\n");
+        if(spe_conf->binds){
+            hal_mem_free(spe_conf->binds);
+            spe_conf->binds = NULL;
+        }
+        return -1;
+    }
+    return 0;
+}
+
+int spe_draw_deinit(spe_draw_conf_t *spe_conf)
+{
+    if(spe_conf == NULL){
+        LOG_DRV_ERROR("spe_draw_deinit invalid param\r\n");
+        return -1;
+    }
+    if(spe_conf->binds){
+        hal_mem_free(spe_conf->binds);
+        spe_conf->binds = NULL;
+    }
+
+    if(spe_conf->font.data){
+        hal_mem_free(spe_conf->font.data);
+        spe_conf->font.data = NULL;
+    }
+    return 0;
+}
+
+int spe_draw_result(spe_draw_conf_t *spe_conf, const pp_spe_out_t *result)
+{
+    if(spe_conf == NULL || result == NULL || result->keypoints == NULL || result->nb_keypoints == 0){
+        LOG_DRV_ERROR("spe_draw_result invalid param\r\n");
+        return -1;
+    }
+
+    device_t *draw = device_find_pattern(DRAW_DEVICE_NAME, DEV_TYPE_VIDEO);
+    if(draw == NULL){
+        return -1;
+    }
+
+    if(result->num_connections > 0 && result->keypoint_connections != NULL){
+        if(spe_conf->binds != NULL){
+            hal_mem_free(spe_conf->binds);
+            spe_conf->binds = NULL;
+        }
+        spe_conf->num_binds = result->num_connections;
+        spe_conf->binds = hal_mem_alloc_fast(sizeof(mpe_draw_bind_t) * spe_conf->num_binds);
+        if(spe_conf->binds == NULL){
+            LOG_DRV_ERROR("spe_draw_result failed\r\n");
+            return -1;
+        }
+        for(int i = 0; i < spe_conf->num_binds; i++){
+            spe_conf->binds[i].keypoint1 = result->keypoint_connections[i*2 + 0];
+            spe_conf->binds[i].keypoint2 = result->keypoint_connections[i*2 + 1];
+            spe_conf->binds[i].color = COLOR_GREEN;
+        }
+    } else {
+        /* No connections in this result: drop stale binds from a previous call */
+        if(spe_conf->binds != NULL){
+            hal_mem_free(spe_conf->binds);
+            spe_conf->binds = NULL;
+        }
+        spe_conf->num_binds = 0;
+    }
+
+    /* No bounding box or class label: SPE is detector-free (keypoints + skeleton only) */
+    int nb_keypoints = result->nb_keypoints;
+    int keypoint_x[nb_keypoints], keypoint_y[nb_keypoints];
+    bool keypoint_valid[nb_keypoints];
+    for (int i = 0; i < nb_keypoints; i++) {
+        keypoint_valid[i] = false;
+        float x = result->keypoints[i].x;
+        float y = result->keypoints[i].y;
+        if (result->keypoints[i].conf >= SPE_MOVENET_PP_CONF_THRESHOLD &&
+            x >= 0 && y >= 0 && x <= 1 && y <= 1) {
+            convert_value(spe_conf->image_width, spe_conf->image_height, x, y, &keypoint_x[i], &keypoint_y[i]);
+            keypoint_valid[i] = true;
+        }
+    }
+
+    draw_line_param_t line_param = {0};
+    for (int i = 0; i < spe_conf->num_binds; i++) {
+        int k1 = spe_conf->binds[i].keypoint1;
+        int k2 = spe_conf->binds[i].keypoint2;
+        if (k1 < nb_keypoints && k2 < nb_keypoints && keypoint_valid[k1] && keypoint_valid[k2]) {
+            line_param.p_dst = spe_conf->p_dst;
+            line_param.dst_width = spe_conf->image_width;
+            line_param.dst_height = spe_conf->image_height;
+            line_param.x1 = keypoint_x[k1];
+            line_param.y1 = keypoint_y[k1];
+            line_param.x2 = keypoint_x[k2];
+            line_param.y2 = keypoint_y[k2];
+            line_param.line_width = spe_conf->line_width;
+            line_param.color = spe_conf->binds[i].color;
+            device_ioctl(draw, DRAW_CMD_LINE, (uint8_t *)&line_param, sizeof(draw_line_param_t));
+        }
+    }
+
+    draw_printf_param_t print_param = {0};
+    draw_dot_param_t dot_param = {0};
+    for (int i = 0; i < nb_keypoints; i++) {
+        if (keypoint_valid[i]) {
+
+            snprintf(print_param.str, sizeof(print_param.str), "%d", i);
+            print_param.p_font = &spe_conf->font;
+            print_param.p_dst = spe_conf->p_dst;
+            print_param.dst_width = spe_conf->image_width;
+            print_param.dst_height = spe_conf->image_height;
+            print_param.x_pos = keypoint_x[i] + spe_conf->dot_width;
+            print_param.y_pos = keypoint_y[i];
+            device_ioctl(draw, DRAW_CMD_PRINTF, (uint8_t *)&print_param, sizeof(draw_printf_param_t));
+
+            dot_param.p_dst = spe_conf->p_dst;
+            dot_param.dst_width = spe_conf->image_width;
+            dot_param.dst_height = spe_conf->image_height;
+            dot_param.x_pos = keypoint_x[i];
+            dot_param.y_pos = keypoint_y[i];
+            dot_param.dot_width = spe_conf->dot_width;
+            dot_param.color = spe_conf->color;
+            device_ioctl(draw, DRAW_CMD_DOT, (uint8_t *)&dot_param, sizeof(draw_dot_param_t));
+        }
+    }
 
     return 0;
 }

--- a/Custom/Hal/ai_draw.h
+++ b/Custom/Hal/ai_draw.h
@@ -55,4 +55,20 @@ typedef struct {
 int iseg_draw_init(iseg_draw_conf_t *iseg_conf);
 int iseg_draw_deinit(iseg_draw_conf_t *iseg_conf);
 int iseg_draw_result(iseg_draw_conf_t *iseg_conf, iseg_detect_t *result, uint32_t instance_index);
+
+typedef struct {
+    uint8_t *p_dst;
+    uint8_t num_binds;
+    mpe_draw_bind_t* binds;
+    uint32_t color;
+    uint32_t image_width;
+    uint32_t image_height;
+    uint32_t line_width;
+    uint32_t dot_width;
+    DRAW_Font_t font;
+} spe_draw_conf_t;
+
+int spe_draw_init(spe_draw_conf_t *spe_conf);
+int spe_draw_deinit(spe_draw_conf_t *spe_conf);
+int spe_draw_result(spe_draw_conf_t *spe_conf, const pp_spe_out_t *result);
 #endif

--- a/Custom/Hal/nn.c
+++ b/Custom/Hal/nn.c
@@ -974,8 +974,69 @@ static cJSON* create_mpe_detection_json(const mpe_detect_t* detection, int index
         }
         cJSON_AddNumberToObject(detection_json, "connection_count", detection->num_connections);
     }
-    
+
     return detection_json;
+}
+
+/**
+ * @brief Create SPE keypoint JSON
+ */
+static cJSON* create_spe_keypoint_json(const spe_keypoint_t* keypoint, int index) {
+    cJSON* keypoint_json = cJSON_CreateObject();
+    if (!keypoint_json) return NULL;
+
+    cJSON_AddNumberToObject(keypoint_json, "index", index);
+    cJSON_AddNumberToObject(keypoint_json, "x", keypoint->x);
+    cJSON_AddNumberToObject(keypoint_json, "y", keypoint->y);
+    cJSON_AddNumberToObject(keypoint_json, "confidence", keypoint->conf);
+
+    return keypoint_json;
+}
+
+/**
+ * @brief Create SPE pose result JSON (detector-free single instance, no bounding box)
+ */
+static cJSON* create_spe_pose_json(const pp_spe_out_t* spe_result, int index) {
+    cJSON* pose_json = cJSON_CreateObject();
+    if (!pose_json) return NULL;
+
+    cJSON_AddNumberToObject(pose_json, "index", index);
+
+    // Add keypoints array
+    cJSON* keypoints_array = cJSON_CreateArray();
+    if (keypoints_array) {
+        for (uint32_t i = 0; i < spe_result->nb_keypoints; i++) {
+            cJSON* keypoint_json = create_spe_keypoint_json(&spe_result->keypoints[i], i);
+            if (keypoint_json) {
+                // Add keypoint name if available
+                if (spe_result->keypoint_names && spe_result->keypoint_names[i]) {
+                    cJSON_AddStringToObject(keypoint_json, "name", spe_result->keypoint_names[i]);
+                }
+                cJSON_AddItemToArray(keypoints_array, keypoint_json);
+            }
+        }
+        cJSON_AddItemToObject(pose_json, "keypoints", keypoints_array);
+    }
+    cJSON_AddNumberToObject(pose_json, "keypoint_count", spe_result->nb_keypoints);
+
+    // Add connections array if available
+    if (spe_result->keypoint_connections && spe_result->num_connections > 0) {
+        cJSON* connections_array = cJSON_CreateArray();
+        if (connections_array) {
+            for (uint8_t i = 0; i < spe_result->num_connections; i++) {
+                cJSON* connection_json = cJSON_CreateObject();
+                if (connection_json) {
+                    cJSON_AddNumberToObject(connection_json, "from", spe_result->keypoint_connections[i * 2]);
+                    cJSON_AddNumberToObject(connection_json, "to", spe_result->keypoint_connections[i * 2 + 1]);
+                    cJSON_AddItemToArray(connections_array, connection_json);
+                }
+            }
+            cJSON_AddItemToObject(pose_json, "connections", connections_array);
+        }
+        cJSON_AddNumberToObject(pose_json, "connection_count", spe_result->num_connections);
+    }
+
+    return pose_json;
 }
 
 /**
@@ -1018,7 +1079,24 @@ cJSON* nn_create_ai_result_json(const nn_result_t* ai_result) {
             cJSON_AddItemToObject(result_json, "poses", poses_array);
         }
         cJSON_AddNumberToObject(result_json, "pose_count", ai_result->mpe.nb_detect);
-        
+
+        // Add empty detection results for consistency
+        cJSON_AddItemToObject(result_json, "detections", cJSON_CreateArray());
+        cJSON_AddNumberToObject(result_json, "detection_count", 0);
+
+    } else if (ai_result->type == PP_TYPE_SPE && ai_result->spe.keypoints != NULL &&
+               ai_result->spe.nb_keypoints > 0) {
+        // Single-Pose Estimation results (detector-free, one instance, no bounding box)
+        cJSON* poses_array = cJSON_CreateArray();
+        if (poses_array) {
+            cJSON* pose_json = create_spe_pose_json(&ai_result->spe, 0);
+            if (pose_json) {
+                cJSON_AddItemToArray(poses_array, pose_json);
+            }
+            cJSON_AddItemToObject(result_json, "poses", poses_array);
+        }
+        cJSON_AddNumberToObject(result_json, "pose_count", 1);
+
         // Add empty detection results for consistency
         cJSON_AddItemToObject(result_json, "detections", cJSON_CreateArray());
         cJSON_AddNumberToObject(result_json, "detection_count", 0);

--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -610,6 +610,7 @@ static aicam_result_t ai_create_camera_pipeline_nodes(const ai_service_config_t 
     camera_config.bpp = config->bpp;
     camera_config.format = config->format;
     camera_config.ai_enabled = config->ai_enabled;
+    camera_config.overlay_results = config->overlay_results;
     
     // Create encoder node configuration
     video_encoder_config_t encoder_config;
@@ -674,6 +675,7 @@ static aicam_result_t ai_create_ai_pipeline_nodes(const ai_service_config_t *con
     ai_config.max_detections = config->max_detections;
     ai_config.processing_interval = config->processing_interval;
     ai_config.enabled = config->ai_enabled;
+    ai_config.overlay_results = config->overlay_results;
     ai_config.enable_drawing = config->enable_drawing;
     
     // Create AI node
@@ -794,6 +796,56 @@ aicam_result_t ai_set_inference_enabled(aicam_bool_t enabled)
 aicam_bool_t ai_get_inference_enabled(void)
 {
     return g_ai_service.config.ai_enabled;
+}
+
+aicam_result_t ai_set_overlay_results(aicam_bool_t overlay_results)
+{
+    if (!g_ai_service.ai_pipeline_initialized || !g_ai_service.ai_node) {
+        LOG_SVC_ERROR("AI pipeline not initialized");
+        return AICAM_ERROR_NOT_INITIALIZED;
+    }
+
+    // Update configuration
+    g_ai_service.config.overlay_results = overlay_results;
+
+    // Update AI node configuration
+    video_ai_config_t ai_config;
+    aicam_result_t result = video_ai_node_get_config(g_ai_service.ai_node, &ai_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to get AI node config: %d", result);
+        return result;
+    }
+    ai_config.overlay_results = overlay_results;
+    result = video_ai_node_set_config(g_ai_service.ai_node, &ai_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to set AI node config: %d", result);
+        return result;
+    }
+
+    // Update camera node config
+    video_camera_config_t camera_config;
+    result = video_camera_node_get_config(g_ai_service.camera_node, &camera_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to get camera node config: %d", result);
+        return result;
+    }
+    camera_config.overlay_results = overlay_results;
+    result = video_camera_node_set_config(g_ai_service.camera_node, &camera_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to set camera node config: %d", result);
+        return result;
+    }
+
+    // update to json config
+    json_config_set_overlay_results(overlay_results);
+
+    LOG_SVC_INFO("AI overlay results %s", overlay_results ? "enabled" : "disabled");
+    return AICAM_OK;
+}
+
+aicam_bool_t ai_get_overlay_results(void)
+{
+    return g_ai_service.config.overlay_results;
 }
 
 aicam_result_t ai_set_nms_threshold(uint32_t threshold)
@@ -1176,6 +1228,7 @@ void ai_get_normal_config(ai_service_config_t *config)
     config->max_detections = 32;
     config->processing_interval = 1;
     config->ai_enabled = AICAM_TRUE;
+    config->overlay_results = json_config_get_overlay_results();
     config->enable_stats = AICAM_TRUE;
     config->enable_drawing = AICAM_FALSE;
     config->enable_debug = AICAM_FALSE;
@@ -1196,6 +1249,7 @@ void ai_get_ai_config(ai_service_config_t *config)
     config->max_detections = 32;
     config->processing_interval = 1;
     config->ai_enabled = AICAM_TRUE;
+    config->overlay_results = json_config_get_overlay_results();
     config->enable_stats = AICAM_TRUE;
     config->enable_debug = AICAM_FALSE;
     config->enable_drawing = AICAM_TRUE;

--- a/Custom/Services/AI/ai_service.h
+++ b/Custom/Services/AI/ai_service.h
@@ -37,6 +37,7 @@ typedef struct {
     uint32_t max_detections;              // Maximum detections per frame
     uint32_t processing_interval;         // AI processing interval (frames)
     aicam_bool_t ai_enabled;              // AI processing enabled
+    aicam_bool_t overlay_results;         // Draw AI results onto encoded frames
     aicam_bool_t enable_stats;            // Enable statistics logging
     aicam_bool_t enable_debug;            // Enable debug logging
     aicam_bool_t enable_drawing;          // Enable AI result drawing
@@ -207,6 +208,19 @@ aicam_result_t ai_set_inference_enabled(aicam_bool_t enabled);
  * @return AI inference enabled status
  */
 aicam_bool_t ai_get_inference_enabled(void);
+
+/**
+ * @brief Enable/disable drawing AI results onto encoded frames
+ * @param overlay_results Overlay enabled flag
+ * @return aicam_result_t Operation result
+ */
+aicam_result_t ai_set_overlay_results(aicam_bool_t overlay_results);
+
+/**
+ * @brief Get AI overlay results status
+ * @return AI overlay results status
+ */
+aicam_bool_t ai_get_overlay_results(void);
 
 /**
  * @brief Set AI NMS threshold

--- a/Custom/Services/MQTT/mqtt_service.c
+++ b/Custom/Services/MQTT/mqtt_service.c
@@ -3389,6 +3389,9 @@ int mqtt_service_publish_ai_result(const char *topic,
             detection_count = ai_result->ai_result.od.nb_detect;
         } else if (ai_result->ai_result.type == PP_TYPE_MPE) {
             detection_count = ai_result->ai_result.mpe.nb_detect;
+        } else if (ai_result->ai_result.type == PP_TYPE_SPE) {
+            // SPE is detector-free single instance: one pose when keypoints exist
+            detection_count = (ai_result->ai_result.spe.nb_keypoints > 0) ? 1 : 0;
         } else if (ai_result->ai_result.type == PP_TYPE_ISEG) {
             detection_count = ai_result->ai_result.iseg.nb_detect;
         }

--- a/Custom/Services/Web/api/api_ai_management_module.c
+++ b/Custom/Services/Web/api/api_ai_management_module.c
@@ -232,11 +232,13 @@ static aicam_result_t ai_management_get_thresholds_handler(http_handler_context_
     cJSON* data = cJSON_CreateObject();
     cJSON_AddNumberToObject(data, "nms_threshold", nms_threshold);
     cJSON_AddNumberToObject(data, "confidence_threshold", confidence_threshold);
-    
+    cJSON_AddBoolToObject(data, "overlay_results", ai_get_overlay_results());
+
     // Add threshold descriptions
     cJSON* descriptions = cJSON_CreateObject();
     cJSON_AddStringToObject(descriptions, "nms_threshold", "Non-Maximum Suppression threshold (0-100)");
     cJSON_AddStringToObject(descriptions, "confidence_threshold", "AI confidence threshold (0-100)");
+    cJSON_AddStringToObject(descriptions, "overlay_results", "Draw AI results onto encoded video frames");
     cJSON_AddItemToObject(data, "descriptions", descriptions);
     
     api_response_success(ctx, cJSON_Print(data), "AI threshold configuration retrieved");
@@ -309,10 +311,25 @@ static aicam_result_t ai_management_set_thresholds_handler(http_handler_context_
         }
     }
 
-    
+    // Update overlay results if provided
+    cJSON* overlay_item = cJSON_GetObjectItem(request, "overlay_results");
+    if (overlay_item && cJSON_IsBool(overlay_item)) {
+        aicam_bool_t overlay_value = cJSON_IsTrue(overlay_item) ? AICAM_TRUE : AICAM_FALSE;
+        aicam_result_t overlay_result = ai_set_overlay_results(overlay_value);
+        if (overlay_result == AICAM_OK) {
+            cJSON_AddStringToObject(response_data, "overlay_results", "updated");
+            cJSON_AddItemToArray(updated, cJSON_CreateString("overlay_results"));
+        } else {
+            cJSON_AddStringToObject(response_data, "overlay_results", "failed");
+            cJSON_AddItemToArray(errors, cJSON_CreateString("Failed to set overlay results"));
+        }
+    }
+
+
     // Add current values to response
     cJSON_AddNumberToObject(response_data, "current_nms_threshold", ai_get_nms_threshold());
     cJSON_AddNumberToObject(response_data, "current_confidence_threshold", ai_get_confidence_threshold());
+    cJSON_AddBoolToObject(response_data, "current_overlay_results", ai_get_overlay_results());
     
     // Add errors and updated arrays
     cJSON_AddItemToObject(response_data, "errors", errors);


### PR DESCRIPTION
## What

Two related fixes to AI result handling, submitted together per Harry's guidance
(mail thread, 2026-07-02; he confirmed the intended design for both and suggested
they ride in one PR).

**1. SPE (single-pose estimation) results are no longer dropped.**
A custom `pp_spe_movenet` model loads and runs, but its output never leaves the
device: `nn_create_ai_result_json()` serializes only OD/MPE/ISEG, so SPE reports
carry an empty `poses[]` (`pose_count: 0`), and the `ai_draw_service` result
switch logs `Unsupported AI result type: 6`. This PR:

- serializes `pp_spe_out_t` under `poses[]`, mirroring the MPE JSON shape
  (`keypoints[] {index, x, y, confidence, name}`, `keypoint_count`,
  `connections[] {from, to}`, `connection_count`) — single instance, no
  bounding box, since SPE is detector-free (`Custom/Hal/nn.c`)
- adds an SPE draw path: keypoints + skeleton, mirroring the MPE drawing minus
  the box and class label (`Custom/Hal/ai_draw.{c,h}`,
  `Custom/Core/Video/ai_draw_service.{c,h}`)
- adds the missing SPE cases in `mqtt_service.c` (`detection_count` in
  `mqtt_service_publish_ai_result`) and `quick_bootstrap.c`
  (`qb_ai_has_detections`)

**2. AI overlays can be disabled without disabling inference.**
The camera-node draw callback fires whenever `ai_enabled` is true, so results
are always burned into the encoded output (RTSP/RTMP/JPEG). The
`overlay_results` flag already existed in `video_ai_config_t` but nothing read
it. This PR wires it end to end:

- the draw-callback gate in `video_camera_node.c` now also requires
  `overlay_results`
- plumbed through `ai_service` (propagation at pipeline creation +
  `ai_set/get_overlay_results()`), persisted in `json_config`/NVS, included in
  config JSON import/export, and exposed on `GET/POST /api/v1/ai/params`

**Stock behavior is unchanged:** the default is overlay ON at every layer
(defaults table, NVS-miss fallback writes `true`, node defaults), so existing
users see no difference unless they explicitly set `overlay_results: false`.
Happy to move the API surface elsewhere if you'd prefer it outside `ai/params`.

## Why

We deploy single-pose models on the NE301 and publish keypoint results over
MQTT under tight bandwidth budgets, while still needing clean (overlay-free)
encoded video on demand. SPE result handling and the clean-output gate are
the two firmware gaps for that (asks 5 and 13 in our thread).

## Testing

On an NE301 (WiFi variant, previously on 2.1.0.66), self-built from this branch
with the `camthink/ne301-dev` image (`VERSION_BUILD=82`) and OTA-flashed:

- Flash + boot + versions OK; `GET /ai/params` reports `overlay_results: true`
  by default on a unit whose NVS never had the key
- MPE regression (`model/validation/upload`, custom `pp_mpe_yolo_v8` model,
  2-person image): poses/confidences/keypoints identical to the pre-flash
  baseline
- SPE (`pp_spe_movenet`, MoveNet 17-keypoint): validation upload now returns
  `type: 6 / single_pose_estimation`, `pose_count: 1`, 17 named keypoints and
  19 connections (previously empty `poses[]`); annotated output image shows
  keypoints drawn, no box
- MQTT: a real `device/capture` report on `.../upload/report` carries the SPE
  `poses[]` end to end through `system_service` → `publish_image_with_ai`
- Overlay gate: `POST /ai/params {"overlay_results": false}` → RTSP frame is
  clean while `ai_enabled: true`; the value survives a reboot (NVS); setting it
  back `true` restores stock behavior at runtime
- OD regression (stock YOLOv8n model): 2 persons detected on the same test image
- Factory image restored afterwards; the unit is back on its original firmware

Changes are marked per the Community Edition license via the two commits on
this branch.
