### PR TITLE
Add metadata-only MQTT report mode

### DIFF
--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -282,6 +282,9 @@
 #define NVS_KEY_MQTT_STATUS_INTERVAL    "mqtt_sts_iv"
 #define NVS_KEY_MQTT_ENABLE_HEARTBEAT   "mqtt_en_hb"
 #define NVS_KEY_MQTT_HEARTBEAT_INTERVAL "mqtt_hb_iv"
+
+// Report content
+#define NVS_KEY_MQTT_REPORT_CONTENT     "mqtt_rpt_ct"
  
  // Work mode configuration key names
  #define NVS_KEY_WORK_MODE           "work_mode"

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -522,6 +522,7 @@ static void parse_mqtt_service(cJSON *json, mqtt_service_config_t *cfg)
     json_get_uint32(json, "status_report_interval_ms", &cfg->status_report_interval_ms);
     json_get_bool(json, "enable_heartbeat", &cfg->enable_heartbeat);
     json_get_uint32(json, "heartbeat_interval_ms", &cfg->heartbeat_interval_ms);
+    json_get_uint8(json, "report_content", &cfg->report_content);
 }
 
 static void parse_work_mode(cJSON *json, work_mode_config_t *cfg)
@@ -1031,6 +1032,7 @@ static cJSON *serialize_mqtt_service(const mqtt_service_config_t *cfg)
     cJSON_AddNumberToObject(json, "status_report_interval_ms", cfg->status_report_interval_ms);
     cJSON_AddBoolToObject(json, "enable_heartbeat", cfg->enable_heartbeat);
     cJSON_AddNumberToObject(json, "heartbeat_interval_ms", cfg->heartbeat_interval_ms);
+    cJSON_AddNumberToObject(json, "report_content", cfg->report_content);
 
     return json;
 }

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -523,6 +523,9 @@ static void parse_mqtt_service(cJSON *json, mqtt_service_config_t *cfg)
     json_get_bool(json, "enable_heartbeat", &cfg->enable_heartbeat);
     json_get_uint32(json, "heartbeat_interval_ms", &cfg->heartbeat_interval_ms);
     json_get_uint8(json, "report_content", &cfg->report_content);
+    if (cfg->report_content > MQTT_REPORT_CONTENT_METADATA_ONLY) {
+        cfg->report_content = MQTT_REPORT_CONTENT_FULL;  // normalize unknown imported values
+    }
 }
 
 static void parse_work_mode(cJSON *json, work_mode_config_t *cfg)

--- a/Custom/Core/System/json_config_mgr.c
+++ b/Custom/Core/System/json_config_mgr.c
@@ -255,7 +255,8 @@
         .enable_status_report = AICAM_TRUE,
         .status_report_interval_ms = 60000,
         .enable_heartbeat = AICAM_TRUE,
-        .heartbeat_interval_ms = 30000
+        .heartbeat_interval_ms = 30000,
+        .report_content = MQTT_REPORT_CONTENT_FULL
     }
  };
 

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -310,6 +310,15 @@ typedef struct {
 } mqtt_base_config_t;
 
 /**
+ * @brief Data report content mode
+ * @note Selects what the capture/report flow publishes on the data report topic
+ */
+typedef enum {
+    MQTT_REPORT_CONTENT_FULL = 0,           // Image + metadata + AI result (stock behavior)
+    MQTT_REPORT_CONTENT_METADATA_ONLY = 1,  // Metadata + AI result only, no image
+} mqtt_report_content_t;
+
+/**
  * @brief Extended MQTT service configuration
  * @note Combines base config with application-specific settings
  */
@@ -337,6 +346,7 @@ typedef struct {
     uint32_t status_report_interval_ms;          // Status report interval (ms)
     aicam_bool_t enable_heartbeat;               // Enable heartbeat
     uint32_t heartbeat_interval_ms;              // Heartbeat interval (ms)
+    uint8_t report_content;                      // Report content mode (mqtt_report_content_t)
 } mqtt_service_config_t;
 
 /** Stored in image_config_t.isp_mode — built-in profiles vs NVS-backed custom IQ. */

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -314,7 +314,7 @@ typedef struct {
  * @note Selects what the capture/report flow publishes on the data report topic
  */
 typedef enum {
-    MQTT_REPORT_CONTENT_FULL = 0,           // Image + metadata + AI result (stock behavior)
+    MQTT_REPORT_CONTENT_FULL = 0,           // Image + metadata + AI result
     MQTT_REPORT_CONTENT_METADATA_ONLY = 1,  // Metadata + AI result only, no image
 } mqtt_report_content_t;
 

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -312,6 +312,8 @@ typedef struct {
 /**
  * @brief Data report content mode
  * @note Selects what the capture/report flow publishes on the data report topic
+ * @note Applies to the normal capture path; the Quick_Bootstrap fast-capture
+ *       path builds its report independently and always sends the full report
  */
 typedef enum {
     MQTT_REPORT_CONTENT_FULL = 0,           // Image + metadata + AI result

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -1161,6 +1161,10 @@ aicam_result_t json_config_save_mqtt_service_config_to_nvs(const mqtt_service_co
     if (result != AICAM_OK)
         LOG_CORE_ERROR("Failed to save MQTT heartbeat interval to NVS");
 
+    result = json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->report_content);
+    if (result != AICAM_OK)
+        LOG_CORE_ERROR("Failed to save MQTT report content mode to NVS");
+
     LOG_CORE_INFO("MQTT full service configuration saved to NVS successfully");
     return result;
 }
@@ -2237,6 +2241,12 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         config->mqtt_service.heartbeat_interval_ms = (int)temp_uint32;
     else
         json_config_nvs_write_uint32(NVS_KEY_MQTT_HEARTBEAT_INTERVAL, (uint32_t)config->mqtt_service.heartbeat_interval_ms);
+
+    result = json_config_nvs_read_uint8(NVS_KEY_MQTT_REPORT_CONTENT, &temp_uint8);
+    if (result == AICAM_OK)
+        config->mqtt_service.report_content = temp_uint8;
+    else
+        json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->mqtt_service.report_content);
 
     // Note: RTMP config is now part of video_stream_mode, loaded below
 

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -2246,10 +2246,14 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         json_config_nvs_write_uint32(NVS_KEY_MQTT_HEARTBEAT_INTERVAL, (uint32_t)config->mqtt_service.heartbeat_interval_ms);
 
     result = json_config_nvs_read_uint8(NVS_KEY_MQTT_REPORT_CONTENT, &temp_uint8);
-    if (result == AICAM_OK)
+    if (result == AICAM_OK &&
+        (temp_uint8 == MQTT_REPORT_CONTENT_FULL || temp_uint8 == MQTT_REPORT_CONTENT_METADATA_ONLY)) {
         config->mqtt_service.report_content = temp_uint8;
-    else
+    } else {
+        // Missing or out-of-range stored value: normalize to full and persist it
+        config->mqtt_service.report_content = MQTT_REPORT_CONTENT_FULL;
         json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->mqtt_service.report_content);
+    }
 
     // Note: RTMP config is now part of video_stream_mode, loaded below
 

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -1161,9 +1161,12 @@ aicam_result_t json_config_save_mqtt_service_config_to_nvs(const mqtt_service_co
     if (result != AICAM_OK)
         LOG_CORE_ERROR("Failed to save MQTT heartbeat interval to NVS");
 
-    result = json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->report_content);
-    if (result != AICAM_OK)
+    // Do not overwrite an earlier field's failure status with this write's success
+    aicam_result_t write_res = json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->report_content);
+    if (write_res != AICAM_OK) {
         LOG_CORE_ERROR("Failed to save MQTT report content mode to NVS");
+        result = write_res;
+    }
 
     LOG_CORE_INFO("MQTT full service configuration saved to NVS successfully");
     return result;

--- a/Custom/Services/MQTT/mqtt_service.c
+++ b/Custom/Services/MQTT/mqtt_service.c
@@ -3391,12 +3391,14 @@ int mqtt_service_publish_ai_result(const char *topic,
         buffer_free(device_info);
     }
 
-    // Add AI result if provided
+    // Add AI result if provided (explicit null on absence or serialization
+    // failure keeps the payload shape stable for consumers)
+    cJSON *ai_json = NULL;
     if (ai_result && ai_result->ai_result.is_valid) {
-        cJSON *ai_json = create_ai_result_json(ai_result);
-        if (ai_json) {
-            cJSON_AddItemToObject(root, "ai_result", ai_json);
-        }
+        ai_json = create_ai_result_json(ai_result);
+    }
+    if (ai_json) {
+        cJSON_AddItemToObject(root, "ai_result", ai_json);
     }
     else
     {

--- a/Custom/Services/MQTT/mqtt_service.c
+++ b/Custom/Services/MQTT/mqtt_service.c
@@ -91,6 +91,7 @@ typedef struct {
     uint32_t status_report_interval_ms;          // Status report interval (ms)
     aicam_bool_t enable_heartbeat;               // Enable heartbeat
     uint32_t heartbeat_interval_ms;              // Heartbeat interval (ms)
+    uint8_t report_content;                      // Report content mode (mqtt_report_content_t)
 } mqtt_service_extended_config_t;
 
 typedef struct {
@@ -1092,6 +1093,7 @@ static aicam_result_t mqtt_config_persistent_to_runtime(const mqtt_service_confi
     runtime->status_report_interval_ms = persistent->status_report_interval_ms;
     runtime->enable_heartbeat = persistent->enable_heartbeat;
     runtime->heartbeat_interval_ms = persistent->heartbeat_interval_ms;
+    runtime->report_content = persistent->report_content;
 
     return AICAM_OK;
 }
@@ -1130,6 +1132,7 @@ static aicam_result_t mqtt_config_runtime_to_persistent(const mqtt_service_exten
     persistent->status_report_interval_ms = runtime->status_report_interval_ms;
     persistent->enable_heartbeat = runtime->enable_heartbeat;
     persistent->heartbeat_interval_ms = runtime->heartbeat_interval_ms;
+    persistent->report_content = runtime->report_content;
 
     return AICAM_OK;
 }
@@ -2161,6 +2164,7 @@ aicam_result_t mqtt_service_get_topic_config(mqtt_service_topic_config_t *config
     config->status_report_interval_ms = g_mqtt_service.config.status_report_interval_ms;
     config->enable_heartbeat = g_mqtt_service.config.enable_heartbeat;
     config->heartbeat_interval_ms = g_mqtt_service.config.heartbeat_interval_ms;
+    config->report_content = g_mqtt_service.config.report_content;
     
     return AICAM_OK;
 }
@@ -2202,10 +2206,24 @@ aicam_result_t mqtt_service_set_topic_config(const mqtt_service_topic_config_t *
     g_mqtt_service.config.status_report_interval_ms = config->status_report_interval_ms;
     g_mqtt_service.config.enable_heartbeat = config->enable_heartbeat;
     g_mqtt_service.config.heartbeat_interval_ms = config->heartbeat_interval_ms;
+    g_mqtt_service.config.report_content = config->report_content;
     
     LOG_SVC_DEBUG("MQTT service topic configuration updated");
     
     return AICAM_OK;
+}
+
+/**
+ * @brief Get the configured data report content mode
+ */
+mqtt_report_content_t mqtt_service_get_report_content(void)
+{
+    // Treat uninitialized service or an out-of-range stored value as stock behavior
+    if (g_mqtt_service.initialized &&
+        g_mqtt_service.config.report_content == MQTT_REPORT_CONTENT_METADATA_ONLY) {
+        return MQTT_REPORT_CONTENT_METADATA_ONLY;
+    }
+    return MQTT_REPORT_CONTENT_FULL;
 }
 
 /* ==================== Event Management ==================== */
@@ -3338,7 +3356,7 @@ int mqtt_service_publish_ai_result(const char *topic,
                                 const mqtt_ai_result_t *ai_result,
                                 int qos)
 {
-    if (!metadata || !ai_result) {
+    if (!metadata) {
         return MQTT_ERR_INVALID_ARG;
     }
     
@@ -3359,10 +3377,30 @@ int mqtt_service_publish_ai_result(const char *topic,
         cJSON_AddItemToObject(root, "metadata", meta_json);
     }
     
-    // Add AI result
-    cJSON *ai_json = create_ai_result_json(ai_result);
-    if (ai_json) {
-        cJSON_AddItemToObject(root, "ai_result", ai_json);
+    //Add device info
+    device_info_config_t *device_info = (device_info_config_t *)buffer_calloc(1, sizeof(device_info_config_t));
+    if (device_info) {
+        if (device_service_get_info(device_info) == AICAM_OK) {
+            cJSON *device_json = create_device_info_json(device_info);
+            if (device_json) {
+                cJSON_AddItemToObject(root, "device_info", device_json);
+            }
+        } else {
+            LOG_SVC_WARN("Failed to get device information, reporting without it");
+        }
+        buffer_free(device_info);
+    }
+
+    // Add AI result if provided
+    if (ai_result && ai_result->ai_result.is_valid) {
+        cJSON *ai_json = create_ai_result_json(ai_result);
+        if (ai_json) {
+            cJSON_AddItemToObject(root, "ai_result", ai_json);
+        }
+    }
+    else
+    {
+        cJSON_AddItemToObject(root, "ai_result", cJSON_CreateNull());
     }
     
     // Convert to JSON string
@@ -3384,7 +3422,7 @@ int mqtt_service_publish_ai_result(const char *topic,
     
     // Get detection count based on result type
     uint32_t detection_count = 0;
-    if (ai_result->ai_result.is_valid) {
+    if (ai_result && ai_result->ai_result.is_valid) {
         if (ai_result->ai_result.type == PP_TYPE_OD) {
             detection_count = ai_result->ai_result.od.nb_detect;
         } else if (ai_result->ai_result.type == PP_TYPE_MPE) {

--- a/Custom/Services/MQTT/mqtt_service.h
+++ b/Custom/Services/MQTT/mqtt_service.h
@@ -78,6 +78,8 @@ typedef struct {
     int status_report_interval_ms;       // Status report interval
     aicam_bool_t enable_heartbeat;       // Enable heartbeat
     int heartbeat_interval_ms;           // Heartbeat interval
+
+    uint8_t report_content;              // Report content mode (mqtt_report_content_t)
 } mqtt_service_topic_config_t;
 
 /* ==================== MQTT Service Interface Functions ==================== */
@@ -287,6 +289,12 @@ aicam_result_t mqtt_service_get_topic_config(mqtt_service_topic_config_t *config
  */
 aicam_result_t mqtt_service_set_topic_config(const mqtt_service_topic_config_t *config);
 
+/**
+ * @brief Get the configured data report content mode
+ * @return mqtt_report_content_t Report content mode (full when unset or service not initialized)
+ */
+mqtt_report_content_t mqtt_service_get_report_content(void);
+
 /* ==================== Event Management ==================== */
 
 /**
@@ -428,7 +436,7 @@ int mqtt_service_publish_image_with_ai(const char *topic,
  * @brief Upload image metadata and AI results only (no image data)
  * @param topic MQTT topic to publish to (NULL = use default data report topic)
  * @param metadata Image metadata
- * @param ai_result AI inference result
+ * @param ai_result AI inference result (can be NULL if no AI processing)
  * @param qos Quality of Service (0, 1, 2), -1 = use default
  * @return int Message ID or error code
  * 

--- a/Custom/Services/System/system_service.c
+++ b/Custom/Services/System/system_service.c
@@ -3602,6 +3602,7 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
     aicam_bool_t mqtt_uploaded = AICAM_FALSE;
     aicam_bool_t webhook_succeeded = AICAM_FALSE;
     aicam_bool_t mqtt_available = mqtt_service_is_running();
+    aicam_bool_t metadata_only = (mqtt_service_get_report_content() == MQTT_REPORT_CONTENT_METADATA_ONLY);
 
     step_start_time = rtc_get_uptime_ms();
 
@@ -3632,14 +3633,36 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
     // Step 4: Check MQTT connection and upload
     step_start_time = rtc_get_uptime_ms();
     if (mqtt_available && mqtt_service_is_connected()) {
-        LOG_SVC_INFO("[TIMING] MQTT connected - uploading image");
+        LOG_SVC_INFO("[TIMING] MQTT connected - publishing report");
         
         // Determine upload method based on image size
         const uint32_t size_threshold = 1024 * 1024; // 1MB
         int mqtt_result;
         uint64_t upload_start_time = rtc_get_uptime_ms();
         
-        if (jpeg_size < size_threshold) {
+        if (metadata_only) {
+            // Metadata-only report - metadata + AI result without the image payload
+            LOG_SVC_INFO("[TIMING] Report content is metadata_only - publishing without image");
+            mqtt_result = mqtt_service_publish_ai_result(
+                NULL, // Use default topic
+                &metadata,
+                ai_result_ptr,
+                -1 // Use default QoS
+            );
+            uint64_t upload_end_time = rtc_get_uptime_ms();
+            uint64_t upload_duration = upload_end_time - upload_start_time;
+
+            if (mqtt_result >= 0) {
+                LOG_SVC_INFO("[TIMING] Metadata-only report published successfully (msg_id: %d, upload duration: %lu ms)",
+                            mqtt_result, (unsigned long)upload_duration);
+                upload_result = AICAM_OK;
+                mqtt_uploaded = AICAM_TRUE;
+            } else {
+                LOG_SVC_ERROR("[TIMING] Metadata-only report publish failed: %d (upload duration: %lu ms)",
+                             mqtt_result, (unsigned long)upload_duration);
+                upload_result = AICAM_ERROR;
+            }
+        } else if (jpeg_size < size_threshold) {
             // Small image - single upload
             LOG_SVC_INFO("[TIMING] Using single upload (size: %u bytes)", jpeg_size);
             mqtt_result = mqtt_service_publish_image_with_ai(
@@ -3782,13 +3805,15 @@ aicam_result_t system_service_capture_and_upload_mqtt(aicam_bool_t enable_ai,
         step_start_time = rtc_get_uptime_ms();
         LOG_SVC_INFO("[TIMING] Step 6: Waiting for publish confirmation...");
 
-        // Calculate dynamic timeout based on message size
+        // Calculate dynamic timeout based on the size actually published
         // Base timeout: 5s + 2s per 10KB of data
-        uint32_t puback_timeout = 5000 + (jpeg_size / 10240) * 2000;
+        // (metadata-only reports are KB-scale JSON, covered by the base timeout)
+        uint32_t published_size = metadata_only ? 0 : jpeg_size;
+        uint32_t puback_timeout = 5000 + (published_size / 10240) * 2000;
         if (puback_timeout > 60000) {
             puback_timeout = 60000;  // Cap at 60 seconds max
         }
-        LOG_SVC_DEBUG("[TIMING] PUBACK timeout: %u ms (based on %u bytes)", puback_timeout, jpeg_size);
+        LOG_SVC_DEBUG("[TIMING] PUBACK timeout: %u ms (based on %u bytes)", puback_timeout, published_size);
 
         if(mqtt_service_wait_for_event(MQTT_EVENT_PUBLISHED, AICAM_TRUE, puback_timeout) != AICAM_OK){
             LOG_SVC_ERROR("[TIMING] Step 6 FAILED: Wait for published event failed");

--- a/Custom/Services/Web/api/api_mqtt_module.c
+++ b/Custom/Services/Web/api/api_mqtt_module.c
@@ -66,6 +66,34 @@ static void free_mqtt_config_strings(ms_mqtt_config_t *config)
 }
 
 /**
+ * @brief Map a report content mode to its API string form
+ */
+static const char *report_content_to_str(uint8_t mode)
+{
+    return mode == MQTT_REPORT_CONTENT_METADATA_ONLY ? "metadata_only" : "full";
+}
+
+/**
+ * @brief Parse a report content mode from its API string form
+ * @return AICAM_OK on a recognized value, error otherwise
+ */
+static aicam_result_t parse_report_content(const cJSON *item, uint8_t *mode)
+{
+    if (!cJSON_IsString(item)) {
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+    if (strcmp(item->valuestring, "full") == 0) {
+        *mode = MQTT_REPORT_CONTENT_FULL;
+        return AICAM_OK;
+    }
+    if (strcmp(item->valuestring, "metadata_only") == 0) {
+        *mode = MQTT_REPORT_CONTENT_METADATA_ONLY;
+        return AICAM_OK;
+    }
+    return AICAM_ERROR_INVALID_PARAM;
+}
+
+/**
  * @brief Safe string comparison, handle NULL pointers
  */
 static int safe_strcmp(const char* str1, const char* str2) {
@@ -287,6 +315,8 @@ static aicam_result_t mqtt_config_get_handler(http_handler_context_t* ctx)
         // cJSON_AddNumberToObject(qos, "status_qos", topic_config.status_qos);
         // cJSON_AddNumberToObject(qos, "command_qos", topic_config.command_qos);
         cJSON_AddItemToObject(response_json, "qos", qos);
+
+        cJSON_AddStringToObject(response_json, "report_content", report_content_to_str(topic_config.report_content));
         
         //cJSON *auto_subscribe = cJSON_CreateObject();
         //cJSON_AddBoolToObject(auto_subscribe, "auto_subscribe_receive", topic_config.auto_subscribe_receive);
@@ -350,6 +380,14 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
         return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "Invalid JSON");
     }
     
+    // Validate report content mode up front (applied with the topic config below)
+    uint8_t report_content_mode = MQTT_REPORT_CONTENT_FULL;
+    cJSON *report_content = cJSON_GetObjectItem(request_json, "report_content");
+    if (report_content && parse_report_content(report_content, &report_content_mode) != AICAM_OK) {
+        cJSON_Delete(request_json);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "report_content must be 'full' or 'metadata_only'");
+    }
+
     // Get current configuration
     ms_mqtt_config_t config;
     aicam_result_t result = mqtt_service_get_config(&config);
@@ -505,7 +543,7 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
     cJSON *topics = cJSON_GetObjectItem(request_json, "topics");
     cJSON *qos = cJSON_GetObjectItem(request_json, "qos");
     
-    if (topics || qos) {
+    if (topics || qos || report_content) {
         mqtt_service_topic_config_t topic_config;
         result = mqtt_service_get_topic_config(&topic_config);
         if (result == AICAM_OK) {
@@ -543,6 +581,11 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
             
             // Note: auto_subscribe and message_config are not exposed in GET handler
             
+            // Update report content mode if provided (validated above)
+            if (report_content) {
+                topic_config.report_content = report_content_mode;
+            }
+
             // Apply topic configuration
             result = mqtt_service_set_topic_config(&topic_config);
             if (result != AICAM_OK) {


### PR DESCRIPTION
Adds a persisted report_content config (full | metadata_only) selecting what the capture/report flow publishes on the MQTT data report topic. In metadata_only mode the report carries metadata + device_info + ai_result as JSON via mqtt_service_publish_ai_result() (previously uncalled), with no base64 image. Default is full; stock behavior is unchanged.

- Persisted alongside the other extended MQTT config fields (NVS + config import/export), exposed as "full" | "metadata_only" in GET/POST mqtt/config; unrecognized values return 400.
- publish_ai_result() payload aligned with the full report: device_info block added, NULL/invalid AI result publishes ai_result: null.
- The PUBACK wait is sized from the payload actually published rather than the captured image size.
- Webhook delivery and the fast-capture (Quick_Bootstrap) path are unchanged; happy to extend the flag there in a follow-up if wanted. Also open to relocating the config key if you prefer a different home for it.

Testing on an NE301 (WiFi):
- Same scene, same build: 108,635 B report in full mode vs 420 B in metadata_only (metadata + device_info + ai_result, no image_data/encoding keys).
- Fresh unit default is full; full-mode report shape unchanged.
- Setting persists across reboot; a topics/qos POST that omits report_content leaves it unchanged; invalid values return 400.
- Image remains retrievable on demand (RTSP frame pull) while reports are metadata_only.