### PR TITLE
Add configurable inference cadence and continuous AI-result telemetry

### DIFF
--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -62,6 +62,7 @@
  #define NVS_KEY_CONFIDENCE          "confidence"
  #define NVS_KEY_NMS_THRESHOLD       "nms_thresh"
  #define NVS_KEY_OVERLAY_RESULTS     "overlay_results"
+ #define NVS_KEY_INFER_INTERVAL      "ai_infer_iv"
  
  // Power mode configuration key names
  #define NVS_KEY_POWER_CURRENT_MODE  "power_cur_mode"
@@ -286,6 +287,11 @@
 
 // Report content
 #define NVS_KEY_MQTT_REPORT_CONTENT     "mqtt_rpt_ct"
+
+// Continuous AI telemetry
+#define NVS_KEY_MQTT_TELEMETRY_ENABLE   "mqtt_tel_en"
+#define NVS_KEY_MQTT_TELEMETRY_TOPIC    "mqtt_t_tel"
+#define NVS_KEY_MQTT_TELEMETRY_QOS      "mqtt_q_tel"
  
  // Work mode configuration key names
  #define NVS_KEY_WORK_MODE           "work_mode"

--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -395,6 +395,7 @@ aicam_result_t json_config_load_webhook_from_nvs(webhook_config_t *config);
  uint32_t json_config_crc32(const void *data, size_t length);
  uint64_t json_config_get_timestamp(void);
  aicam_result_t json_config_validate_ranges(const aicam_global_config_t *config);
+ aicam_bool_t json_config_enforce_invariants(aicam_global_config_t *config);
  void json_config_generate_device_name_from_mac(char *device_name, size_t name_size, const char *mac_address);
  
  

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -1188,6 +1188,10 @@ aicam_result_t json_config_parse_json_object(const char *json_str, aicam_global_
         parse_auth_mgr(auth_mgr, &config->auth_mgr);
 
     cJSON_Delete(root);
+
+    // Cross-group invariants can only be checked once every section has parsed
+    json_config_enforce_invariants(config);
+
     return result;
 }
 

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -108,6 +108,7 @@ static void parse_ai_debug(cJSON *json, ai_debug_config_t *cfg)
     json_get_uint32(json, "confidence_threshold", &cfg->confidence_threshold);
     json_get_uint32(json, "nms_threshold", &cfg->nms_threshold);
     json_get_bool(json, "overlay_results", &cfg->overlay_results);
+    json_get_uint32(json, "inference_interval_ms", &cfg->inference_interval_ms);
 }
 
 static void parse_power_mode(cJSON *json, power_mode_config_t *cfg)
@@ -527,6 +528,9 @@ static void parse_mqtt_service(cJSON *json, mqtt_service_config_t *cfg)
     if (cfg->report_content > MQTT_REPORT_CONTENT_METADATA_ONLY) {
         cfg->report_content = MQTT_REPORT_CONTENT_FULL;  // normalize unknown imported values
     }
+    json_get_bool(json, "telemetry_enabled", &cfg->telemetry_enabled);
+    json_get_string(json, "telemetry_topic", cfg->telemetry_topic, sizeof(cfg->telemetry_topic));
+    json_get_uint8(json, "telemetry_qos", &cfg->telemetry_qos);
 }
 
 static void parse_work_mode(cJSON *json, work_mode_config_t *cfg)
@@ -664,6 +668,7 @@ static cJSON *serialize_ai_debug(const ai_debug_config_t *cfg)
     cJSON_AddNumberToObject(json, "confidence_threshold", cfg->confidence_threshold);
     cJSON_AddNumberToObject(json, "nms_threshold", cfg->nms_threshold);
     cJSON_AddBoolToObject(json, "overlay_results", cfg->overlay_results);
+    cJSON_AddNumberToObject(json, "inference_interval_ms", cfg->inference_interval_ms);
     return json;
 }
 
@@ -1038,6 +1043,9 @@ static cJSON *serialize_mqtt_service(const mqtt_service_config_t *cfg)
     cJSON_AddBoolToObject(json, "enable_heartbeat", cfg->enable_heartbeat);
     cJSON_AddNumberToObject(json, "heartbeat_interval_ms", cfg->heartbeat_interval_ms);
     cJSON_AddNumberToObject(json, "report_content", cfg->report_content);
+    cJSON_AddBoolToObject(json, "telemetry_enabled", cfg->telemetry_enabled);
+    cJSON_AddStringToObject(json, "telemetry_topic", cfg->telemetry_topic);
+    cJSON_AddNumberToObject(json, "telemetry_qos", cfg->telemetry_qos);
 
     return json;
 }

--- a/Custom/Core/System/json_config_mgr.c
+++ b/Custom/Core/System/json_config_mgr.c
@@ -36,7 +36,8 @@
          .ai_1_active = AICAM_FALSE,
          .confidence_threshold = 50,
          .nms_threshold = 50,
-         .overlay_results = AICAM_TRUE
+         .overlay_results = AICAM_TRUE,
+         .inference_interval_ms = 0
      },
      
      .power_mode_config = {
@@ -257,7 +258,12 @@
         .status_report_interval_ms = 60000,
         .enable_heartbeat = AICAM_TRUE,
         .heartbeat_interval_ms = 30000,
-        .report_content = MQTT_REPORT_CONTENT_FULL
+        .report_content = MQTT_REPORT_CONTENT_FULL,
+
+        // Continuous AI telemetry
+        .telemetry_enabled = AICAM_FALSE,
+        .telemetry_topic = "aicam/data/telemetry",
+        .telemetry_qos = 0
     }
  };
 
@@ -815,6 +821,20 @@
  aicam_bool_t json_config_get_overlay_results(void)
  {
      return g_json_config_ctx.current_config.ai_debug.overlay_results;
+ }
+
+ aicam_result_t json_config_set_inference_interval_ms(uint32_t interval_ms)
+ {
+     g_json_config_ctx.current_config.ai_debug.inference_interval_ms = interval_ms;
+
+     // update to NVS
+     json_config_nvs_write_uint32(NVS_KEY_INFER_INTERVAL, interval_ms);
+     return AICAM_OK;
+ }
+
+ uint32_t json_config_get_inference_interval_ms(void)
+ {
+     return g_json_config_ctx.current_config.ai_debug.inference_interval_ms;
  }
 
  /*=================== Work Mode Configuration API Implementation ====================*/

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -32,6 +32,7 @@
      uint32_t confidence_threshold;             // Confidence threshold 0-100
      uint32_t nms_threshold;                    // NMS threshold 0-100
      aicam_bool_t overlay_results;  // Draw AI results onto encoded frames
+     uint32_t inference_interval_ms;            // AI inference pacing interval in ms (0 = every frame)
  } ai_debug_config_t;
  
 typedef struct {
@@ -350,6 +351,11 @@ typedef struct {
     aicam_bool_t enable_heartbeat;               // Enable heartbeat
     uint32_t heartbeat_interval_ms;              // Heartbeat interval (ms)
     uint8_t report_content;                      // Report content mode (mqtt_report_content_t)
+
+    // Continuous AI telemetry
+    aicam_bool_t telemetry_enabled;              // Publish AI results continuously
+    char telemetry_topic[MAX_TOPIC_LENGTH];      // Telemetry topic
+    uint8_t telemetry_qos;                       // Telemetry QoS (0-2)
 } mqtt_service_config_t;
 
 /** Stored in image_config_t.isp_mode — built-in profiles vs NVS-backed custom IQ. */
@@ -842,6 +848,19 @@ aicam_result_t json_config_set_overlay_results(aicam_bool_t overlay_results);
  */
 aicam_bool_t json_config_get_overlay_results(void);
 
+/**
+ * @brief Set AI inference pacing interval
+ * @param interval_ms Interval in milliseconds (0 = process every frame)
+ * @return aicam_result_t Operation result
+ */
+aicam_result_t json_config_set_inference_interval_ms(uint32_t interval_ms);
+
+/**
+ * @brief Get AI inference pacing interval
+ * @return Interval in milliseconds (0 = process every frame)
+ */
+uint32_t json_config_get_inference_interval_ms(void);
+
 
 /**
  * @brief Get mqtt service configuration
@@ -1011,6 +1030,7 @@ aicam_result_t json_config_delete_webhook_ca_cert(void);
 #define JSON_CONFIG_GET_CONFIDENCE(config)     ((config)->ai_debug.confidence_threshold)
 #define JSON_CONFIG_GET_NMS_THRESHOLD(config)  ((config)->ai_debug.nms_threshold)
 #define JSON_CONFIG_GET_OVERLAY_RESULTS(config) ((config)->ai_debug.overlay_results)
+#define JSON_CONFIG_GET_INFER_INTERVAL(config) ((config)->ai_debug.inference_interval_ms)
 
 // Macros for quick access to power mode configuration
 #define JSON_CONFIG_GET_POWER_MODE(config)     ((config)->power_mode_config.current_mode)

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -68,6 +68,13 @@ aicam_result_t json_config_save_ai_debug_config_to_nvs(const ai_debug_config_t *
         result = overlay_result;
     }
 
+    // Do not overwrite an earlier field's failure status with this write's success
+    aicam_result_t interval_result = json_config_nvs_write_uint32(NVS_KEY_INFER_INTERVAL, config->inference_interval_ms);
+    if (interval_result != AICAM_OK) {
+        LOG_CORE_ERROR("Failed to save inference interval to NVS");
+        result = interval_result;
+    }
+
     LOG_CORE_INFO("AI debug configuration saved to NVS successfully");
     return result;
 }
@@ -1174,6 +1181,25 @@ aicam_result_t json_config_save_mqtt_service_config_to_nvs(const mqtt_service_co
         result = write_res;
     }
 
+    // Do not overwrite an earlier field's failure status with these writes' success
+    aicam_result_t telemetry_result = json_config_nvs_write_bool(NVS_KEY_MQTT_TELEMETRY_ENABLE, config->telemetry_enabled);
+    if (telemetry_result != AICAM_OK) {
+        LOG_CORE_ERROR("Failed to save MQTT telemetry enable to NVS");
+        result = telemetry_result;
+    }
+
+    telemetry_result = json_config_nvs_write_string(NVS_KEY_MQTT_TELEMETRY_TOPIC, config->telemetry_topic);
+    if (telemetry_result != AICAM_OK) {
+        LOG_CORE_ERROR("Failed to save MQTT telemetry topic to NVS");
+        result = telemetry_result;
+    }
+
+    telemetry_result = json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_QOS, config->telemetry_qos);
+    if (telemetry_result != AICAM_OK) {
+        LOG_CORE_ERROR("Failed to save MQTT telemetry qos to NVS");
+        result = telemetry_result;
+    }
+
     LOG_CORE_INFO("MQTT full service configuration saved to NVS successfully");
     return result;
 }
@@ -1460,6 +1486,12 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         config->ai_debug.overlay_results = temp_bool;
     else
         json_config_nvs_write_bool(NVS_KEY_OVERLAY_RESULTS, config->ai_debug.overlay_results);
+
+    result = json_config_nvs_read_uint32(NVS_KEY_INFER_INTERVAL, &temp_uint32);
+    if (result == AICAM_OK)
+        config->ai_debug.inference_interval_ms = temp_uint32;
+    else
+        json_config_nvs_write_uint32(NVS_KEY_INFER_INTERVAL, config->ai_debug.inference_interval_ms);
 
     // Load power mode configuration
     result = json_config_nvs_read_uint32(NVS_KEY_POWER_CURRENT_MODE, &temp_uint32);
@@ -2266,6 +2298,22 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         config->mqtt_service.report_content = MQTT_REPORT_CONTENT_FULL;
         json_config_nvs_write_uint8(NVS_KEY_MQTT_REPORT_CONTENT, config->mqtt_service.report_content);
     }
+
+    result = json_config_nvs_read_bool(NVS_KEY_MQTT_TELEMETRY_ENABLE, &temp_bool);
+    if (result == AICAM_OK)
+        config->mqtt_service.telemetry_enabled = temp_bool;
+    else
+        json_config_nvs_write_bool(NVS_KEY_MQTT_TELEMETRY_ENABLE, config->mqtt_service.telemetry_enabled);
+
+    result = json_config_nvs_read_string(NVS_KEY_MQTT_TELEMETRY_TOPIC, config->mqtt_service.telemetry_topic, sizeof(config->mqtt_service.telemetry_topic));
+    if (result != AICAM_OK)
+        json_config_nvs_write_string(NVS_KEY_MQTT_TELEMETRY_TOPIC, config->mqtt_service.telemetry_topic);
+
+    result = json_config_nvs_read_uint8(NVS_KEY_MQTT_TELEMETRY_QOS, &temp_uint8);
+    if (result == AICAM_OK)
+        config->mqtt_service.telemetry_qos = temp_uint8;
+    else
+        json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_QOS, config->mqtt_service.telemetry_qos);
 
     // Note: RTMP config is now part of video_stream_mode, loaded below
 

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -2510,6 +2510,13 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         json_config_save_to_nvs(config);  // Will call flush internally
     }
 
+    // Stored values violating a cross-field invariant are corrected in place;
+    // persist the correction so the next boot loads a consistent state
+    if (json_config_enforce_invariants(config)) {
+        json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_ENABLE,
+                                    config->mqtt_service.telemetry_enabled);
+    }
+
     LOG_CORE_INFO("Config loaded from NVS successfully");
     return AICAM_OK;
 }

--- a/Custom/Core/System/json_config_utils.c
+++ b/Custom/Core/System/json_config_utils.c
@@ -94,6 +94,29 @@
  }
  
  
+ aicam_bool_t json_config_enforce_invariants(aicam_global_config_t *config)
+ {
+     if (!config) {
+         return AICAM_FALSE;
+     }
+
+     // telemetry_enabled requires a non-zero inference interval (telemetry
+     // publishes once per paced inference). The Web APIs enforce this on
+     // write, but NVS loading and config-file import apply raw values, so
+     // normalize once all groups are populated. In-memory only: the caller
+     // decides whether to persist, since an imported config may still be
+     // rejected by validation and must not mutate stored state.
+     if (config->mqtt_service.telemetry_enabled &&
+         config->ai_debug.inference_interval_ms == 0) {
+         LOG_CORE_WARN("telemetry_enabled requires inference_interval_ms > 0; disabling telemetry");
+         config->mqtt_service.telemetry_enabled = 0;
+         return AICAM_TRUE;
+     }
+
+     return AICAM_FALSE;
+ }
+ 
+ 
  uint32_t json_config_crc32(const void *data, size_t length)
  {
      // (Copied verbatim from original file)

--- a/Custom/Core/Video/video_ai_node.c
+++ b/Custom/Core/Video/video_ai_node.c
@@ -454,8 +454,26 @@ aicam_result_t video_ai_node_get_best_nn_result(video_node_t *node, nn_result_t 
 
     // Release cache mutex (no index changes for non-destructive read)
     osMutexRelease(data->cache_mutex);
-    
+
     //LOG_CORE_DEBUG("Retrieved latest NN result from cache: %d detections", result->od.nb_detect);
+    return AICAM_OK;
+}
+
+aicam_result_t video_ai_node_set_result_callback(video_node_t *node,
+                                                 video_ai_result_callback_t callback,
+                                                 void *user_data)
+{
+    if (!node) {
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+
+    video_ai_node_data_t *data = (video_ai_node_data_t*)video_node_get_private_data(node);
+    if (!data) {
+        return AICAM_ERROR_INVALID_PARAM;
+    }
+
+    data->result_callback = callback;
+    data->result_callback_user_data = user_data;
     return AICAM_OK;
 }
 
@@ -526,6 +544,21 @@ static aicam_result_t video_ai_process_frame(video_ai_node_data_t *data,
         return AICAM_ERROR_INVALID_PARAM;
     }
 
+    // Pace inference to the configured interval. Sleep in bounded slices so
+    // config changes and pipeline stop are picked up within ~100 ms, and
+    // never inside a camera ioctl (it holds the camera mutex while blocking).
+    if (data->config.inference_interval_ms != 0)
+    {
+        uint32_t elapsed_ms = osKernelGetTickCount() - data->last_inference_tick;
+        if (elapsed_ms < data->config.inference_interval_ms)
+        {
+            uint32_t remaining_ms = data->config.inference_interval_ms - elapsed_ms;
+            osDelay(remaining_ms < 100 ? remaining_ms : 100);
+            *output_frame = NULL;
+            return AICAM_OK;
+        }
+    }
+
     // Check processing interval
     if (data->config.processing_interval > 1)
     {
@@ -594,7 +627,11 @@ static aicam_result_t video_ai_process_frame(video_ai_node_data_t *data,
 
 
     // Call NN module to process frame
+    uint32_t infer_start_tick = osKernelGetTickCount();
     int nn_ret = nn_inference_frame(input_frame_buffer, camera_buffer_with_frame_id.size, &nn_result);
+    uint32_t inference_time_ms = osKernelGetTickCount() - infer_start_tick;
+    // Anchor pacing to the attempt so inference errors keep the configured cadence
+    data->last_inference_tick = infer_start_tick;
 
     // return pipe2 buffer
     device_ioctl(camera_dev, CAM_CMD_RETURN_PIPE2_BUFFER, input_frame_buffer, 0);
@@ -644,6 +681,14 @@ static aicam_result_t video_ai_process_frame(video_ai_node_data_t *data,
             {
                 LOG_CORE_WARN("Cache mutex timeout, failed %lu times", lock_fail_count);
             }
+        }
+
+        // Hand the fresh result to the registered consumer while the
+        // postprocess output buffers still hold this inference's data
+        if (data->result_callback)
+        {
+            data->result_callback(&nn_result, frame_id, inference_time_ms,
+                                  data->result_callback_user_data);
         }
     }
 

--- a/Custom/Core/Video/video_ai_node.h
+++ b/Custom/Core/Video/video_ai_node.h
@@ -34,6 +34,7 @@ typedef struct {
     uint32_t nms_threshold;               // NMS threshold (0-100)
     uint32_t max_detections;              // Maximum detections per frame
     uint32_t processing_interval;         // Processing interval (frames)
+    uint32_t inference_interval_ms;       // Inference pacing interval in ms (0 = every frame)
     uint32_t bpp;                         // Bits per pixel
     aicam_bool_t enabled;                 // AI processing enabled
     aicam_bool_t overlay_results;         // Overlay detection results
@@ -64,6 +65,18 @@ typedef struct {
 } nn_result_with_frame_id_t;
 
 /**
+ * @brief Inference result callback
+ * @details Invoked on the AI node's processing thread immediately after a
+ *          successful inference, while the postprocess output buffers still
+ *          hold that inference's data. The callee must copy whatever it needs
+ *          before returning and must not block.
+ */
+typedef void (*video_ai_result_callback_t)(const nn_result_t *result,
+                                           uint32_t frame_id,
+                                           uint32_t inference_time_ms,
+                                           void *user_data);
+
+/**
  * @brief AI node private data
  */
 typedef struct {
@@ -72,6 +85,9 @@ typedef struct {
     video_ai_stats_t stats;               // AI statistics
     nn_model_info_t model_info;           // NN model information
     uint32_t frame_counter;               // Frame counter for interval processing
+    uint32_t last_inference_tick;         // Tick of the last inference attempt (pacing)
+    video_ai_result_callback_t result_callback; // Post-inference result callback
+    void *result_callback_user_data;      // Opaque pointer for result_callback
     uint8_t *current_buffer;              // Current frame buffer
     aicam_bool_t is_initialized;          // Initialization status
     aicam_bool_t is_running;              // Running status
@@ -199,6 +215,17 @@ aicam_result_t video_ai_node_get_nn_result(video_node_t *node, nn_result_t *resu
  * @return Operation result
  */
 aicam_result_t video_ai_node_get_best_nn_result(video_node_t *node, nn_result_t *result, uint32_t frame_id);
+
+/**
+ * @brief Register a callback invoked after each successful inference
+ * @param node AI node handle
+ * @param callback Callback function (NULL to unregister)
+ * @param user_data Opaque pointer passed to the callback
+ * @return Operation result
+ */
+aicam_result_t video_ai_node_set_result_callback(video_node_t *node,
+                                                 video_ai_result_callback_t callback,
+                                                 void *user_data);
 
 /* ==================== Control Commands ==================== */
 

--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -107,7 +107,7 @@ static void ai_telemetry_publish(void);
 static void ai_telemetry_reconcile_pipeline(void);
 static void ai_telemetry_invalidate_snapshot(void);
 static aicam_result_t ai_telemetry_init(void);
-static void ai_telemetry_stop_task(void);
+static aicam_bool_t ai_telemetry_stop_task(void);
 static void ai_telemetry_deinit(void);
 
 static void ai_camera_pipeline_event_callback(video_pipeline_t *pipeline,
@@ -1671,12 +1671,16 @@ static aicam_result_t ai_telemetry_init(void)
 
 /**
  * @brief Stop the telemetry task, unregister the callback, release the hub hold
- * @details Idempotent. After this returns, the reconciler and publisher are
- *          gone and no NEW result callback will fire, but a callback already
- *          in flight on the AI node thread may still be running — the caller
- *          must stop the AI pipeline before freeing snapshot resources.
+ * @details Idempotent. After this returns TRUE, the reconciler and publisher
+ *          are gone and no NEW result callback will fire, but a callback
+ *          already in flight on the AI node thread may still be running — the
+ *          caller must stop the AI pipeline before freeing snapshot resources.
+ * @return AICAM_TRUE when no task remains (never started, or joined);
+ *         AICAM_FALSE when the task did not exit within the join window, in
+ *         which case the task handle and hub hold are left in place so a
+ *         later call can retry the join.
  */
-static void ai_telemetry_stop_task(void)
+static aicam_bool_t ai_telemetry_stop_task(void)
 {
     g_ai_telemetry.initialized = AICAM_FALSE;
 
@@ -1687,9 +1691,15 @@ static void ai_telemetry_stop_task(void)
     if (g_ai_telemetry.task_handle) {
         g_ai_telemetry.task_running = AICAM_FALSE;
         osEventFlagsSet(g_ai_telemetry.event_flags, AI_TELEMETRY_FLAG_RESULT);
-        // Wait for the task to leave its loop before it can be freed
-        for (uint32_t waited_ms = 0; !g_ai_telemetry.task_exited && waited_ms < 2000; waited_ms += 100) {
+        // Wait for the task to leave its loop. Worst-case exit latency is one
+        // flag-wait timeout (1 s) plus one publish blocked on a degraded link
+        // (network timeout, 3 s default), so 6 s covers it with margin.
+        for (uint32_t waited_ms = 0; !g_ai_telemetry.task_exited && waited_ms < 6000; waited_ms += 100) {
             osDelay(100);
+        }
+        if (!g_ai_telemetry.task_exited) {
+            LOG_SVC_ERROR("Telemetry task did not exit within the join window");
+            return AICAM_FALSE;
         }
         g_ai_telemetry.task_handle = NULL;
     }
@@ -1699,6 +1709,8 @@ static void ai_telemetry_stop_task(void)
         video_hub_unsubscribe(g_ai_telemetry.hub_sub_id);
         g_ai_telemetry.hub_sub_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
     }
+
+    return AICAM_TRUE;
 }
 
 /**
@@ -1707,11 +1719,16 @@ static void ai_telemetry_stop_task(void)
  *          the AI node thread is stopped first (so no result callback is in
  *          flight); ai_service_stop does this via ai_pipeline_stop(). The
  *          init-failure paths are safe because the AI pipeline is not yet
- *          running when ai_telemetry_init runs.
+ *          running when ai_telemetry_init runs. If the publisher task cannot
+ *          be joined, the shared resources are deliberately leaked rather
+ *          than freed under a live task.
  */
 static void ai_telemetry_deinit(void)
 {
-    ai_telemetry_stop_task();
+    if (!ai_telemetry_stop_task()) {
+        LOG_SVC_ERROR("Leaking telemetry resources: publisher task still running");
+        return;
+    }
 
     if (g_ai_telemetry.event_flags) {
         osEventFlagsDelete(g_ai_telemetry.event_flags);

--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -20,6 +20,9 @@
 #include "video_camera_node.h"
 #include "device_service.h"
 #include "Services/Video/video_stream_hub.h"
+#include "mqtt_service.h"
+#include "drtc.h"
+#include "common_utils.h"
 
 /* ==================== AI Service Context ==================== */
 
@@ -56,7 +59,56 @@ typedef struct {
 
 static ai_service_context_t g_ai_service = {0};
 
+/* ==================== Continuous AI Telemetry Context ==================== */
+
+#define AI_TELEMETRY_FLAG_RESULT    0x0001U
+#define AI_TELEMETRY_MAX_DETECTS    32   // matches max_detections in the AI configs
+#define AI_TELEMETRY_MAX_KEYPOINTS  64
+
+/**
+ * @brief One published telemetry beat, deep-copied at inference time
+ * @details The pp module rewrites its output buffers on every inference (on
+ *          any path, including captures), so the pointer-backed payloads in
+ *          nn_result_t are rebased into the telemetry-owned buffers below.
+ */
+typedef struct {
+    nn_result_t result;                    // Result with detect/keypoint pointers rebased
+    uint32_t frame_id;                     // Sensor frame the inference ran on
+    uint32_t inference_time_ms;            // Measured wall time of this inference
+    uint64_t timestamp_ms;                 // RTC time the result was snapshotted
+    char model_name[64];                   // From nn_model_info_t.name
+    aicam_bool_t valid;                    // Snapshot holds a publishable result
+} ai_telemetry_snapshot_t;
+
+static struct {
+    aicam_bool_t initialized;              // Telemetry unit initialization status
+    volatile aicam_bool_t task_running;    // Publisher task loop gate
+    volatile aicam_bool_t task_exited;     // Publisher task exit handshake
+    osThreadId_t task_handle;              // Publisher task handle
+    osEventFlagsId_t event_flags;          // New-result signal to the publisher task
+    osMutexId_t snapshot_mutex;            // Guards snapshot and the copy buffers
+    ai_telemetry_snapshot_t snapshot;      // Latest result handed to the publisher
+    od_detect_t *od_detects;               // Deep-copy destination (OD)
+    mpe_detect_t *mpe_detects;             // Deep-copy destination (MPE)
+    spe_keypoint_t *spe_keypoints;         // Deep-copy destination (SPE)
+    iseg_detect_t *iseg_detects;           // Deep-copy destination (ISEG, masks omitted)
+    video_hub_subscriber_id_t hub_sub_id;  // Hub subscription that holds the pipeline running
+} g_ai_telemetry = {0};
+
+static uint8_t ai_telemetry_task_stack[1024 * 4] ALIGN_32 IN_PSRAM;
+
 /* ==================== Internal Function Declarations ==================== */
+
+static void ai_telemetry_result_callback(const nn_result_t *result, uint32_t frame_id,
+                                         uint32_t inference_time_ms, void *user_data);
+static aicam_result_t ai_telemetry_hub_frame_cb(const video_hub_frame_t *frame, void *user_data);
+static void ai_telemetry_task(void *argument);
+static void ai_telemetry_publish(void);
+static void ai_telemetry_reconcile_pipeline(void);
+static void ai_telemetry_invalidate_snapshot(void);
+static aicam_result_t ai_telemetry_init(void);
+static void ai_telemetry_stop_task(void);
+static void ai_telemetry_deinit(void);
 
 static void ai_camera_pipeline_event_callback(video_pipeline_t *pipeline,
                                              uint32_t event_type,
@@ -129,7 +181,12 @@ aicam_result_t ai_service_start(void)
         LOG_SVC_ERROR("Failed to initialize AI pipeline: %d", result);
         return result;
     }
-    
+
+    // Telemetry is auxiliary: a failure here must not take down the service
+    if (ai_telemetry_init() != AICAM_OK) {
+        LOG_SVC_WARN("AI telemetry unavailable, continuing without it");
+    }
+
     g_ai_service.running = AICAM_TRUE;
     g_ai_service.state = SERVICE_STATE_RUNNING;
     g_ai_service.stats.start_time_ms = osKernelGetTickCount();
@@ -150,9 +207,17 @@ aicam_result_t ai_service_stop(void)
     }
     
     LOG_SVC_INFO("Stopping AI Service...");
-    
+
+    // Order matters: stop the telemetry task and unregister the result
+    // callback first (kills the reconciler so it cannot restart the pipeline),
+    // then stop the pipeline so the AI node thread drains any in-flight
+    // callback, and only then free the telemetry snapshot resources.
+    ai_telemetry_stop_task();
+
     // Stop pipeline
     ai_pipeline_stop();
+
+    ai_telemetry_deinit();
     
     g_ai_service.running = AICAM_FALSE;
     g_ai_service.state = SERVICE_STATE_INITIALIZED;
@@ -685,6 +750,7 @@ static aicam_result_t ai_create_ai_pipeline_nodes(const ai_service_config_t *con
     ai_config.nms_threshold = config->nms_threshold;
     ai_config.max_detections = config->max_detections;
     ai_config.processing_interval = config->processing_interval;
+    ai_config.inference_interval_ms = config->inference_interval_ms;
     ai_config.enabled = config->ai_enabled;
     ai_config.overlay_results = config->overlay_results;
     ai_config.enable_drawing = config->enable_drawing;
@@ -857,6 +923,45 @@ aicam_result_t ai_set_overlay_results(aicam_bool_t overlay_results)
 aicam_bool_t ai_get_overlay_results(void)
 {
     return g_ai_service.config.overlay_results;
+}
+
+aicam_result_t ai_set_inference_interval_ms(uint32_t interval_ms)
+{
+    // Any uint32 is a valid interval (0 = every frame); range is validated at
+    // the API boundary where the request value is still a JSON number.
+
+    // Update and persist the configuration first, so the setting also
+    // takes effect (via config) when the pipeline is not running
+    g_ai_service.config.inference_interval_ms = interval_ms;
+    json_config_set_inference_interval_ms(interval_ms);
+
+    if (!g_ai_service.ai_pipeline_initialized || !g_ai_service.ai_node) {
+        LOG_SVC_INFO("AI inference interval set to %u ms (pipeline not active, saved to config)",
+                     (unsigned)interval_ms);
+        return AICAM_OK;
+    }
+
+    // Update AI node configuration
+    video_ai_config_t ai_config;
+    aicam_result_t result = video_ai_node_get_config(g_ai_service.ai_node, &ai_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to get AI node config: %d", result);
+        return result;
+    }
+    ai_config.inference_interval_ms = interval_ms;
+    result = video_ai_node_set_config(g_ai_service.ai_node, &ai_config);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to set AI node config: %d", result);
+        return result;
+    }
+
+    LOG_SVC_INFO("AI inference interval set to %u ms", (unsigned)interval_ms);
+    return AICAM_OK;
+}
+
+uint32_t ai_get_inference_interval_ms(void)
+{
+    return g_ai_service.config.inference_interval_ms;
 }
 
 aicam_result_t ai_set_nms_threshold(uint32_t threshold)
@@ -1099,6 +1204,11 @@ aicam_result_t ai_reload_model(void)
         return result;
     }
 
+    // Drop any telemetry beat latched against the outgoing model: the AI node
+    // thread is now drained (no new beat), and the reload below frees the pp
+    // class-label/keypoint metadata that a latched snapshot still points into.
+    ai_telemetry_invalidate_snapshot();
+
     //reload model
     result = video_ai_node_reload_model(g_ai_service.ai_node);
     if (result != AICAM_OK) {
@@ -1252,6 +1362,383 @@ void ai_print_stats(void)
 
 /* ==================== AI Configuration Functions ==================== */
 
+/* ==================== Continuous AI Telemetry ==================== */
+
+/**
+ * @brief Snapshot a fresh inference result for the telemetry publisher
+ * @details Runs on the AI node's processing thread. Deep-copies the
+ *          pointer-backed payloads before the pp output buffers can be
+ *          rewritten by the next inference, then signals the publisher task.
+ */
+static void ai_telemetry_result_callback(const nn_result_t *result, uint32_t frame_id,
+                                         uint32_t inference_time_ms, void *user_data)
+{
+    (void)user_data;
+
+    if (!g_ai_telemetry.initialized || !mqtt_service_get_telemetry_enabled()) {
+        return;
+    }
+
+    // One beat per inference; the AI node's pacing sets the rate
+
+    // Drop this beat rather than stall the inference thread behind a publish
+    if (osMutexAcquire(g_ai_telemetry.snapshot_mutex, 10) != osOK) {
+        return;
+    }
+
+    ai_telemetry_snapshot_t *snap = &g_ai_telemetry.snapshot;
+    memcpy(&snap->result, result, sizeof(nn_result_t));
+
+    // Rebase the pointer-backed payloads into telemetry-owned buffers
+    switch (result->type) {
+        case PP_TYPE_OD:
+            if (result->od.detects && result->od.nb_detect > 0) {
+                uint8_t count = result->od.nb_detect;
+                if (count > AI_TELEMETRY_MAX_DETECTS) count = AI_TELEMETRY_MAX_DETECTS;
+                memcpy(g_ai_telemetry.od_detects, result->od.detects, count * sizeof(od_detect_t));
+                snap->result.od.detects = g_ai_telemetry.od_detects;
+                snap->result.od.nb_detect = count;
+            }
+            break;
+
+        case PP_TYPE_MPE:
+            if (result->mpe.detects && result->mpe.nb_detect > 0) {
+                uint8_t count = result->mpe.nb_detect;
+                if (count > AI_TELEMETRY_MAX_DETECTS) count = AI_TELEMETRY_MAX_DETECTS;
+                // Keypoints are inline in mpe_detect_t; name/connection pointers
+                // reference model metadata that is stable while the model is loaded
+                memcpy(g_ai_telemetry.mpe_detects, result->mpe.detects, count * sizeof(mpe_detect_t));
+                snap->result.mpe.detects = g_ai_telemetry.mpe_detects;
+                snap->result.mpe.nb_detect = count;
+            }
+            break;
+
+        case PP_TYPE_SPE:
+            if (result->spe.keypoints && result->spe.nb_keypoints > 0) {
+                uint32_t count = result->spe.nb_keypoints;
+                if (count > AI_TELEMETRY_MAX_KEYPOINTS) count = AI_TELEMETRY_MAX_KEYPOINTS;
+                memcpy(g_ai_telemetry.spe_keypoints, result->spe.keypoints, count * sizeof(spe_keypoint_t));
+                snap->result.spe.keypoints = g_ai_telemetry.spe_keypoints;
+                snap->result.spe.nb_keypoints = count;
+            }
+            break;
+
+        case PP_TYPE_ISEG:
+            if (result->iseg.detects && result->iseg.nb_detect > 0) {
+                uint8_t count = result->iseg.nb_detect;
+                if (count > AI_TELEMETRY_MAX_DETECTS) count = AI_TELEMETRY_MAX_DETECTS;
+                memcpy(g_ai_telemetry.iseg_detects, result->iseg.detects, count * sizeof(iseg_detect_t));
+                // Masks stay in the shared pp buffer; the JSON serializer only
+                // reports mask_size, so drop the pointers rather than race on them
+                for (uint8_t i = 0; i < count; i++) {
+                    g_ai_telemetry.iseg_detects[i].mask = NULL;
+                }
+                snap->result.iseg.detects = g_ai_telemetry.iseg_detects;
+                snap->result.iseg.nb_detect = count;
+            }
+            break;
+
+        default:
+            // Remaining types carry no payload the JSON serializer dereferences
+            break;
+    }
+
+    snap->frame_id = frame_id;
+    snap->inference_time_ms = inference_time_ms;
+    snap->timestamp_ms = rtc_get_timestamp_ms();
+    nn_model_info_t model_info;
+    if (ai_service_get_model_info(&model_info) == AICAM_OK) {
+        strncpy(snap->model_name, model_info.name, sizeof(snap->model_name) - 1);
+        snap->model_name[sizeof(snap->model_name) - 1] = '\0';
+    } else {
+        snap->model_name[0] = '\0';
+    }
+    snap->valid = AICAM_TRUE;
+
+    osMutexRelease(g_ai_telemetry.snapshot_mutex);
+
+    osEventFlagsSet(g_ai_telemetry.event_flags, AI_TELEMETRY_FLAG_RESULT);
+}
+
+/**
+ * @brief Hub frame sink for the telemetry subscription
+ * @details Telemetry holds a hub subscription only to keep the AI pipeline
+ *          running (the hub starts/stops it by subscriber refcount); it does
+ *          not consume encoded video, so this callback discards the frame.
+ */
+static aicam_result_t ai_telemetry_hub_frame_cb(const video_hub_frame_t *frame, void *user_data)
+{
+    (void)frame;
+    (void)user_data;
+    return AICAM_OK;
+}
+
+/**
+ * @brief Keep the AI pipeline running while telemetry is enabled
+ * @details Continuous inference otherwise only runs while the video hub has
+ *          subscribers (preview/RTSP/RTMP), so on a headless unit telemetry
+ *          holds its own hub subscription. Going through the hub's refcount
+ *          (rather than calling ai_pipeline_start/stop directly) lets the hub
+ *          serialize start/stop against real viewers under its own mutex, so a
+ *          viewer subscribing as telemetry is disabled cannot be left black.
+ */
+static void ai_telemetry_reconcile_pipeline(void)
+{
+    aicam_bool_t desired = mqtt_service_get_telemetry_enabled();
+
+    if (desired && g_ai_service.ai_pipeline_initialized &&
+        g_ai_telemetry.hub_sub_id == VIDEO_HUB_INVALID_SUBSCRIBER_ID) {
+        video_hub_subscriber_id_t id = video_hub_subscribe(
+            VIDEO_HUB_SUBSCRIBER_CUSTOM, ai_telemetry_hub_frame_cb, NULL, NULL);
+        if (id != VIDEO_HUB_INVALID_SUBSCRIBER_ID) {
+            g_ai_telemetry.hub_sub_id = id;
+            LOG_SVC_INFO("Telemetry enabled: holding AI pipeline via hub subscription %ld",
+                         (long)id);
+        }
+    } else if (!desired && g_ai_telemetry.hub_sub_id != VIDEO_HUB_INVALID_SUBSCRIBER_ID) {
+        video_hub_unsubscribe(g_ai_telemetry.hub_sub_id);
+        LOG_SVC_INFO("Telemetry disabled: released hub subscription %ld",
+                     (long)g_ai_telemetry.hub_sub_id);
+        g_ai_telemetry.hub_sub_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
+    }
+}
+
+/**
+ * @brief Invalidate the latched telemetry snapshot
+ * @details Called from the model-reload path after the AI node thread is
+ *          drained but before the pp module frees the class-label / keypoint
+ *          metadata that the snapshot's copied detect structs still point into.
+ *          Without this a beat latched before the reload would be serialized
+ *          against freed pointers.
+ */
+static void ai_telemetry_invalidate_snapshot(void)
+{
+    if (!g_ai_telemetry.snapshot_mutex) {
+        return;
+    }
+    if (osMutexAcquire(g_ai_telemetry.snapshot_mutex, osWaitForever) != osOK) {
+        return;
+    }
+    g_ai_telemetry.snapshot.valid = AICAM_FALSE;
+    osMutexRelease(g_ai_telemetry.snapshot_mutex);
+    if (g_ai_telemetry.event_flags) {
+        osEventFlagsClear(g_ai_telemetry.event_flags, AI_TELEMETRY_FLAG_RESULT);
+    }
+}
+
+/**
+ * @brief Build and publish one telemetry message from the current snapshot
+ * @details The snapshot mutex is held only across the JSON build; the network
+ *          publish (which can block on a degraded link) runs unlocked.
+ */
+static void ai_telemetry_publish(void)
+{
+    if (osMutexAcquire(g_ai_telemetry.snapshot_mutex, osWaitForever) != osOK) {
+        return;
+    }
+
+    if (!g_ai_telemetry.snapshot.valid) {
+        osMutexRelease(g_ai_telemetry.snapshot_mutex);
+        return;
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        osMutexRelease(g_ai_telemetry.snapshot_mutex);
+        LOG_SVC_ERROR("Failed to create telemetry payload");
+        return;
+    }
+
+    cJSON_AddStringToObject(root, "type", "ai_telemetry");
+    cJSON_AddNumberToObject(root, "timestamp_ms", (double)g_ai_telemetry.snapshot.timestamp_ms);
+    cJSON_AddNumberToObject(root, "frame_id", g_ai_telemetry.snapshot.frame_id);
+    cJSON_AddStringToObject(root, "model_name", g_ai_telemetry.snapshot.model_name);
+    cJSON_AddNumberToObject(root, "inference_time_ms", g_ai_telemetry.snapshot.inference_time_ms);
+
+    // Explicit null on absence keeps the payload shape stable for consumers
+    cJSON *ai_json = NULL;
+    if (g_ai_telemetry.snapshot.result.is_valid) {
+        ai_json = nn_create_ai_result_json(&g_ai_telemetry.snapshot.result);
+    }
+    if (ai_json) {
+        cJSON_AddItemToObject(root, "ai_result", ai_json);
+    } else {
+        cJSON_AddItemToObject(root, "ai_result", cJSON_CreateNull());
+    }
+
+    char *json_str = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    osMutexRelease(g_ai_telemetry.snapshot_mutex);
+
+    if (!json_str) {
+        LOG_SVC_ERROR("Failed to serialize telemetry payload");
+        return;
+    }
+
+    int publish_result = mqtt_service_publish_telemetry(json_str);
+    if (publish_result < 0) {
+        // Expected while the broker is unreachable; QoS/backpressure errors land here too
+        LOG_SVC_DEBUG("Telemetry publish failed: %d", publish_result);
+    }
+
+    buffer_free(json_str);
+}
+
+/**
+ * @brief Telemetry publisher task
+ * @details Publishes on each new-result signal; the wait timeout doubles as
+ *          the pipeline-reconciliation tick so config changes apply within ~1 s.
+ */
+static void ai_telemetry_task(void *argument)
+{
+    (void)argument;
+
+    while (g_ai_telemetry.task_running) {
+        uint32_t flags = osEventFlagsWait(g_ai_telemetry.event_flags, AI_TELEMETRY_FLAG_RESULT,
+                                          osFlagsWaitAny, 1000);
+
+        if (!g_ai_telemetry.task_running) {
+            break;
+        }
+
+        ai_telemetry_reconcile_pipeline();
+
+        if ((int32_t)flags >= 0 && (flags & AI_TELEMETRY_FLAG_RESULT)) {
+            ai_telemetry_publish();
+        }
+    }
+
+    g_ai_telemetry.task_exited = AICAM_TRUE;
+    osThreadExit();
+}
+
+/**
+ * @brief Initialize the telemetry unit and hook it onto the AI node
+ * @note Telemetry is auxiliary: failure here must not fail service start
+ */
+static aicam_result_t ai_telemetry_init(void)
+{
+    if (g_ai_telemetry.initialized) {
+        return AICAM_OK;
+    }
+
+    memset(&g_ai_telemetry, 0, sizeof(g_ai_telemetry));
+    // memset zeroes hub_sub_id to 0, which is a valid subscriber id
+    g_ai_telemetry.hub_sub_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
+
+    g_ai_telemetry.snapshot_mutex = osMutexNew(NULL);
+    g_ai_telemetry.event_flags = osEventFlagsNew(NULL);
+    g_ai_telemetry.od_detects = buffer_calloc(AI_TELEMETRY_MAX_DETECTS, sizeof(od_detect_t));
+    g_ai_telemetry.mpe_detects = buffer_calloc(AI_TELEMETRY_MAX_DETECTS, sizeof(mpe_detect_t));
+    g_ai_telemetry.spe_keypoints = buffer_calloc(AI_TELEMETRY_MAX_KEYPOINTS, sizeof(spe_keypoint_t));
+    g_ai_telemetry.iseg_detects = buffer_calloc(AI_TELEMETRY_MAX_DETECTS, sizeof(iseg_detect_t));
+
+    if (!g_ai_telemetry.snapshot_mutex || !g_ai_telemetry.event_flags ||
+        !g_ai_telemetry.od_detects || !g_ai_telemetry.mpe_detects ||
+        !g_ai_telemetry.spe_keypoints || !g_ai_telemetry.iseg_detects) {
+        LOG_SVC_ERROR("Failed to allocate telemetry resources");
+        ai_telemetry_deinit();
+        return AICAM_ERROR_NO_MEMORY;
+    }
+
+    g_ai_telemetry.task_running = AICAM_TRUE;
+    const osThreadAttr_t task_attributes = {
+        .name = "AITelemetry",
+        .stack_mem = ai_telemetry_task_stack,
+        .stack_size = sizeof(ai_telemetry_task_stack),
+        .priority = osPriorityNormal,
+    };
+    g_ai_telemetry.task_handle = osThreadNew(ai_telemetry_task, NULL, &task_attributes);
+    if (!g_ai_telemetry.task_handle) {
+        LOG_SVC_ERROR("Failed to create telemetry task");
+        g_ai_telemetry.task_running = AICAM_FALSE;
+        ai_telemetry_deinit();
+        return AICAM_ERROR_NO_MEMORY;
+    }
+
+    aicam_result_t result = video_ai_node_set_result_callback(g_ai_service.ai_node,
+                                                              ai_telemetry_result_callback, NULL);
+    if (result != AICAM_OK) {
+        LOG_SVC_ERROR("Failed to register telemetry result callback: %d", result);
+        ai_telemetry_deinit();
+        return result;
+    }
+
+    g_ai_telemetry.initialized = AICAM_TRUE;
+    LOG_SVC_INFO("AI telemetry unit initialized");
+    return AICAM_OK;
+}
+
+/**
+ * @brief Stop the telemetry task, unregister the callback, release the hub hold
+ * @details Idempotent. After this returns, the reconciler and publisher are
+ *          gone and no NEW result callback will fire, but a callback already
+ *          in flight on the AI node thread may still be running — the caller
+ *          must stop the AI pipeline before freeing snapshot resources.
+ */
+static void ai_telemetry_stop_task(void)
+{
+    g_ai_telemetry.initialized = AICAM_FALSE;
+
+    if (g_ai_service.ai_node) {
+        video_ai_node_set_result_callback(g_ai_service.ai_node, NULL, NULL);
+    }
+
+    if (g_ai_telemetry.task_handle) {
+        g_ai_telemetry.task_running = AICAM_FALSE;
+        osEventFlagsSet(g_ai_telemetry.event_flags, AI_TELEMETRY_FLAG_RESULT);
+        // Wait for the task to leave its loop before it can be freed
+        for (uint32_t waited_ms = 0; !g_ai_telemetry.task_exited && waited_ms < 2000; waited_ms += 100) {
+            osDelay(100);
+        }
+        g_ai_telemetry.task_handle = NULL;
+    }
+
+    // Release the pipeline hold now that the reconciler can no longer run
+    if (g_ai_telemetry.hub_sub_id != VIDEO_HUB_INVALID_SUBSCRIBER_ID) {
+        video_hub_unsubscribe(g_ai_telemetry.hub_sub_id);
+        g_ai_telemetry.hub_sub_id = VIDEO_HUB_INVALID_SUBSCRIBER_ID;
+    }
+}
+
+/**
+ * @brief Tear down the telemetry unit
+ * @warning Frees the snapshot mutex and copy buffers. The caller must ensure
+ *          the AI node thread is stopped first (so no result callback is in
+ *          flight); ai_service_stop does this via ai_pipeline_stop(). The
+ *          init-failure paths are safe because the AI pipeline is not yet
+ *          running when ai_telemetry_init runs.
+ */
+static void ai_telemetry_deinit(void)
+{
+    ai_telemetry_stop_task();
+
+    if (g_ai_telemetry.event_flags) {
+        osEventFlagsDelete(g_ai_telemetry.event_flags);
+        g_ai_telemetry.event_flags = NULL;
+    }
+    if (g_ai_telemetry.snapshot_mutex) {
+        osMutexDelete(g_ai_telemetry.snapshot_mutex);
+        g_ai_telemetry.snapshot_mutex = NULL;
+    }
+    if (g_ai_telemetry.od_detects) {
+        buffer_free(g_ai_telemetry.od_detects);
+        g_ai_telemetry.od_detects = NULL;
+    }
+    if (g_ai_telemetry.mpe_detects) {
+        buffer_free(g_ai_telemetry.mpe_detects);
+        g_ai_telemetry.mpe_detects = NULL;
+    }
+    if (g_ai_telemetry.spe_keypoints) {
+        buffer_free(g_ai_telemetry.spe_keypoints);
+        g_ai_telemetry.spe_keypoints = NULL;
+    }
+    if (g_ai_telemetry.iseg_detects) {
+        buffer_free(g_ai_telemetry.iseg_detects);
+        g_ai_telemetry.iseg_detects = NULL;
+    }
+}
+
 void ai_get_normal_config(ai_service_config_t *config)
 {
     if (!config) return;
@@ -1266,6 +1753,7 @@ void ai_get_normal_config(ai_service_config_t *config)
     config->nms_threshold = json_config_get_nms_threshold();
     config->max_detections = 32;
     config->processing_interval = 1;
+    config->inference_interval_ms = json_config_get_inference_interval_ms();
     config->ai_enabled = AICAM_TRUE;
     config->overlay_results = json_config_get_overlay_results();
     config->enable_stats = AICAM_TRUE;
@@ -1287,6 +1775,7 @@ void ai_get_ai_config(ai_service_config_t *config)
     config->nms_threshold = json_config_get_nms_threshold();
     config->max_detections = 32;
     config->processing_interval = 1;
+    config->inference_interval_ms = json_config_get_inference_interval_ms();
     config->ai_enabled = AICAM_TRUE;
     config->overlay_results = json_config_get_overlay_results();
     config->enable_stats = AICAM_TRUE;

--- a/Custom/Services/AI/ai_service.h
+++ b/Custom/Services/AI/ai_service.h
@@ -36,6 +36,7 @@ typedef struct {
     uint32_t nms_threshold;               // NMS threshold (0-100)
     uint32_t max_detections;              // Maximum detections per frame
     uint32_t processing_interval;         // AI processing interval (frames)
+    uint32_t inference_interval_ms;       // AI inference pacing interval in ms (0 = every frame)
     aicam_bool_t ai_enabled;              // AI processing enabled
     aicam_bool_t overlay_results;         // Draw AI results onto encoded frames
     aicam_bool_t enable_stats;            // Enable statistics logging
@@ -221,6 +222,19 @@ aicam_result_t ai_set_overlay_results(aicam_bool_t overlay_results);
  * @return AI overlay results status
  */
 aicam_bool_t ai_get_overlay_results(void);
+
+/**
+ * @brief Set the AI inference pacing interval
+ * @param interval_ms Interval in milliseconds (0 = process every frame)
+ * @return aicam_result_t Operation result
+ */
+aicam_result_t ai_set_inference_interval_ms(uint32_t interval_ms);
+
+/**
+ * @brief Get the AI inference pacing interval
+ * @return Interval in milliseconds (0 = process every frame)
+ */
+uint32_t ai_get_inference_interval_ms(void);
 
 /**
  * @brief Set AI NMS threshold

--- a/Custom/Services/MQTT/mqtt_service.c
+++ b/Custom/Services/MQTT/mqtt_service.c
@@ -92,6 +92,11 @@ typedef struct {
     aicam_bool_t enable_heartbeat;               // Enable heartbeat
     uint32_t heartbeat_interval_ms;              // Heartbeat interval (ms)
     uint8_t report_content;                      // Report content mode (mqtt_report_content_t)
+
+    // Continuous AI telemetry
+    aicam_bool_t telemetry_enabled;              // Publish AI results continuously
+    char telemetry_topic[MAX_TOPIC_LENGTH];      // Telemetry topic
+    uint8_t telemetry_qos;                       // Telemetry QoS (0-2)
 } mqtt_service_extended_config_t;
 
 typedef struct {
@@ -1095,6 +1100,11 @@ static aicam_result_t mqtt_config_persistent_to_runtime(const mqtt_service_confi
     runtime->heartbeat_interval_ms = persistent->heartbeat_interval_ms;
     runtime->report_content = persistent->report_content;
 
+    //copy telemetry configuration
+    runtime->telemetry_enabled = persistent->telemetry_enabled;
+    strcpy(runtime->telemetry_topic, persistent->telemetry_topic);
+    runtime->telemetry_qos = persistent->telemetry_qos;
+
     return AICAM_OK;
 }
 
@@ -1133,6 +1143,11 @@ static aicam_result_t mqtt_config_runtime_to_persistent(const mqtt_service_exten
     persistent->enable_heartbeat = runtime->enable_heartbeat;
     persistent->heartbeat_interval_ms = runtime->heartbeat_interval_ms;
     persistent->report_content = runtime->report_content;
+
+    //copy telemetry configuration
+    persistent->telemetry_enabled = runtime->telemetry_enabled;
+    strcpy(persistent->telemetry_topic, runtime->telemetry_topic);
+    persistent->telemetry_qos = runtime->telemetry_qos;
 
     return AICAM_OK;
 }
@@ -2165,7 +2180,13 @@ aicam_result_t mqtt_service_get_topic_config(mqtt_service_topic_config_t *config
     config->enable_heartbeat = g_mqtt_service.config.enable_heartbeat;
     config->heartbeat_interval_ms = g_mqtt_service.config.heartbeat_interval_ms;
     config->report_content = g_mqtt_service.config.report_content;
-    
+
+    config->telemetry_enabled = g_mqtt_service.config.telemetry_enabled;
+    strncpy(config->telemetry_topic, g_mqtt_service.config.telemetry_topic, sizeof(config->telemetry_topic) - 1);
+    config->telemetry_topic[sizeof(config->telemetry_topic) - 1] = '\0';
+    config->telemetry_qos = g_mqtt_service.config.telemetry_qos;
+
+
     return AICAM_OK;
 }
 
@@ -2207,9 +2228,15 @@ aicam_result_t mqtt_service_set_topic_config(const mqtt_service_topic_config_t *
     g_mqtt_service.config.enable_heartbeat = config->enable_heartbeat;
     g_mqtt_service.config.heartbeat_interval_ms = config->heartbeat_interval_ms;
     g_mqtt_service.config.report_content = config->report_content;
-    
+
+    g_mqtt_service.config.telemetry_enabled = config->telemetry_enabled;
+    strncpy(g_mqtt_service.config.telemetry_topic, config->telemetry_topic, sizeof(g_mqtt_service.config.telemetry_topic) - 1);
+    g_mqtt_service.config.telemetry_topic[sizeof(g_mqtt_service.config.telemetry_topic) - 1] = '\0';
+    g_mqtt_service.config.telemetry_qos = config->telemetry_qos;
+
+
     LOG_SVC_DEBUG("MQTT service topic configuration updated");
-    
+
     return AICAM_OK;
 }
 
@@ -2224,6 +2251,41 @@ mqtt_report_content_t mqtt_service_get_report_content(void)
         return MQTT_REPORT_CONTENT_METADATA_ONLY;
     }
     return MQTT_REPORT_CONTENT_FULL;
+}
+
+/**
+ * @brief Get whether continuous AI telemetry publishing is enabled
+ */
+aicam_bool_t mqtt_service_get_telemetry_enabled(void)
+{
+    // Treat an uninitialized service as telemetry off (stock behavior)
+    if (g_mqtt_service.initialized && g_mqtt_service.config.telemetry_enabled) {
+        return AICAM_TRUE;
+    }
+    return AICAM_FALSE;
+}
+
+/**
+ * @brief Publish a continuous AI telemetry message
+ * @details Fire-and-forget on the configured telemetry topic/QoS. Fails fast
+ *          while disconnected; callers treat failures as dropped beats.
+ */
+int mqtt_service_publish_telemetry(const char *json_str)
+{
+    if (!json_str) {
+        return MQTT_ERR_INVALID_ARG;
+    }
+
+    if (!mqtt_service_get_telemetry_enabled()) {
+        return MQTT_ERR_INVALID_STATE;
+    }
+
+    if (!mqtt_service_is_connected()) {
+        return MQTT_ERR_CONN;
+    }
+
+    return mqtt_service_publish_json(g_mqtt_service.config.telemetry_topic, json_str,
+                                     g_mqtt_service.config.telemetry_qos, 0);
 }
 
 /* ==================== Event Management ==================== */
@@ -3621,6 +3683,14 @@ static aicam_bool_t mqtt_build_topics(const char *mac_str, mqtt_service_config_t
     {
         snprintf(cfg->data_report_topic, sizeof(cfg->data_report_topic),
                 "ne301/%s/upload/report", mac_hex);
+        changed = AICAM_TRUE;
+    }
+
+    if (cfg->telemetry_topic[0] == '\0' ||
+        strcmp(cfg->telemetry_topic, "aicam/data/telemetry") == 0)
+    {
+        snprintf(cfg->telemetry_topic, sizeof(cfg->telemetry_topic),
+                "ne301/%s/upload/telemetry", mac_hex);
         changed = AICAM_TRUE;
     }
 

--- a/Custom/Services/MQTT/mqtt_service.h
+++ b/Custom/Services/MQTT/mqtt_service.h
@@ -80,6 +80,10 @@ typedef struct {
     int heartbeat_interval_ms;           // Heartbeat interval
 
     uint8_t report_content;              // Report content mode (mqtt_report_content_t)
+
+    aicam_bool_t telemetry_enabled;      // Publish AI results continuously
+    char telemetry_topic[128];           // Telemetry topic
+    int telemetry_qos;                   // Telemetry QoS
 } mqtt_service_topic_config_t;
 
 /* ==================== MQTT Service Interface Functions ==================== */
@@ -294,6 +298,19 @@ aicam_result_t mqtt_service_set_topic_config(const mqtt_service_topic_config_t *
  * @return mqtt_report_content_t Report content mode (full when unset or service not initialized)
  */
 mqtt_report_content_t mqtt_service_get_report_content(void);
+
+/**
+ * @brief Get whether continuous AI telemetry publishing is enabled
+ * @return AICAM_TRUE only when the service is initialized and telemetry is enabled
+ */
+aicam_bool_t mqtt_service_get_telemetry_enabled(void);
+
+/**
+ * @brief Publish a continuous AI telemetry message to the telemetry topic
+ * @param json_str Pre-built JSON payload
+ * @return int Message ID or error code (fails fast while disconnected)
+ */
+int mqtt_service_publish_telemetry(const char *json_str);
 
 /* ==================== Event Management ==================== */
 

--- a/Custom/Services/Web/api/api_ai_management_module.c
+++ b/Custom/Services/Web/api/api_ai_management_module.c
@@ -6,6 +6,7 @@
 
 #include "web_api.h"
 #include "ai_service.h"
+#include "mqtt_service.h"
 #include "cJSON.h"
 #include "debug.h"
 #include <string.h>
@@ -233,12 +234,14 @@ static aicam_result_t ai_management_get_thresholds_handler(http_handler_context_
     cJSON_AddNumberToObject(data, "nms_threshold", nms_threshold);
     cJSON_AddNumberToObject(data, "confidence_threshold", confidence_threshold);
     cJSON_AddBoolToObject(data, "overlay_results", ai_get_overlay_results());
+    cJSON_AddNumberToObject(data, "inference_interval_ms", ai_get_inference_interval_ms());
 
     // Add threshold descriptions
     cJSON* descriptions = cJSON_CreateObject();
     cJSON_AddStringToObject(descriptions, "nms_threshold", "Non-Maximum Suppression threshold (0-100)");
     cJSON_AddStringToObject(descriptions, "confidence_threshold", "AI confidence threshold (0-100)");
     cJSON_AddStringToObject(descriptions, "overlay_results", "Draw AI results onto encoded video frames");
+    cJSON_AddStringToObject(descriptions, "inference_interval_ms", "AI inference pacing interval in ms (0 = every frame, or a positive value)");
     cJSON_AddItemToObject(data, "descriptions", descriptions);
     
     api_response_success(ctx, cJSON_Print(data), "AI threshold configuration retrieved");
@@ -325,10 +328,37 @@ static aicam_result_t ai_management_set_thresholds_handler(http_handler_context_
         }
     }
 
+    // Update inference interval if provided (0 = every frame, or any positive ms).
+    // Validate the JSON number here, where a negative / non-finite / out-of-uint32
+    // value can be rejected before it is cast to the uint32 config field.
+    cJSON* interval_item = cJSON_GetObjectItem(request, "inference_interval_ms");
+    if (interval_item && cJSON_IsNumber(interval_item)) {
+        double interval_value = cJSON_GetNumberValue(interval_item);
+        if (interval_value == 0 && mqtt_service_get_telemetry_enabled()) {
+            // Telemetry paces its publishing off this interval, so an unpaced
+            // pipeline is only allowed while telemetry is off
+            cJSON_AddStringToObject(response_data, "inference_interval_ms", "rejected");
+            cJSON_AddItemToArray(errors, cJSON_CreateString("Disable telemetry_enabled before setting inference_interval_ms to 0"));
+        } else if (interval_value >= 0 && interval_value <= 4294967295.0) {  // fits uint32
+            aicam_result_t interval_result = ai_set_inference_interval_ms((uint32_t)interval_value);
+            if (interval_result == AICAM_OK) {
+                cJSON_AddStringToObject(response_data, "inference_interval_ms", "updated");
+                cJSON_AddItemToArray(updated, cJSON_CreateString("inference_interval_ms"));
+            } else {
+                cJSON_AddStringToObject(response_data, "inference_interval_ms", "failed");
+                cJSON_AddItemToArray(errors, cJSON_CreateString("Failed to set inference interval"));
+            }
+        } else {
+            cJSON_AddStringToObject(response_data, "inference_interval_ms", "invalid_range");
+            cJSON_AddItemToArray(errors, cJSON_CreateString("inference_interval_ms must be 0 (every frame) or a positive value in ms"));
+        }
+    }
+
     // Add current values to response
     cJSON_AddNumberToObject(response_data, "current_nms_threshold", ai_get_nms_threshold());
     cJSON_AddNumberToObject(response_data, "current_confidence_threshold", ai_get_confidence_threshold());
     cJSON_AddBoolToObject(response_data, "current_overlay_results", ai_get_overlay_results());
+    cJSON_AddNumberToObject(response_data, "current_inference_interval_ms", ai_get_inference_interval_ms());
     
     // Add errors and updated arrays
     cJSON_AddItemToObject(response_data, "errors", errors);

--- a/Custom/Services/Web/api/api_mqtt_module.c
+++ b/Custom/Services/Web/api/api_mqtt_module.c
@@ -6,6 +6,7 @@
 
 #include "api_mqtt_module.h"
 #include "mqtt_service.h"
+#include "ai_service.h"
 #include "web_api.h"
 #include "web_server.h"
 #include "system_service.h"
@@ -317,7 +318,12 @@ static aicam_result_t mqtt_config_get_handler(http_handler_context_t* ctx)
         cJSON_AddItemToObject(response_json, "qos", qos);
 
         cJSON_AddStringToObject(response_json, "report_content", report_content_to_str(topic_config.report_content));
-        
+
+        cJSON_AddBoolToObject(response_json, "telemetry_enabled", topic_config.telemetry_enabled);
+        cJSON_AddStringToObject(response_json, "telemetry_topic", topic_config.telemetry_topic);
+        cJSON_AddNumberToObject(response_json, "telemetry_qos", topic_config.telemetry_qos);
+
+
         //cJSON *auto_subscribe = cJSON_CreateObject();
         //cJSON_AddBoolToObject(auto_subscribe, "auto_subscribe_receive", topic_config.auto_subscribe_receive);
         //cJSON_AddBoolToObject(auto_subscribe, "auto_subscribe_command", topic_config.auto_subscribe_command);
@@ -379,13 +385,43 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
     if (!request_json) {
         return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "Invalid JSON");
     }
-    
+
     // Validate report content mode up front (applied with the topic config below)
     uint8_t report_content_mode = MQTT_REPORT_CONTENT_FULL;
     cJSON *report_content = cJSON_GetObjectItem(request_json, "report_content");
     if (report_content && parse_report_content(report_content, &report_content_mode) != AICAM_OK) {
         cJSON_Delete(request_json);
         return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "report_content must be 'full' or 'metadata_only'");
+    }
+
+    // Validate telemetry fields up front (applied with the topic config below)
+    cJSON *telemetry_enabled = cJSON_GetObjectItem(request_json, "telemetry_enabled");
+    if (telemetry_enabled && !cJSON_IsBool(telemetry_enabled)) {
+        cJSON_Delete(request_json);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "telemetry_enabled must be a boolean");
+    }
+    if (telemetry_enabled && cJSON_IsTrue(telemetry_enabled)) {
+        // Telemetry publishes one message per paced inference, so it requires a
+        // cadence (a non-zero interval) rather than every-frame inference
+        if (json_config_get_inference_interval_ms() == 0) {
+            cJSON_Delete(request_json);
+            return api_response_error(ctx, API_ERROR_INVALID_REQUEST,
+                                      "telemetry_enabled requires inference_interval_ms > 0 (set via ai/params)");
+        }
+    }
+    cJSON *telemetry_topic = cJSON_GetObjectItem(request_json, "telemetry_topic");
+    if (telemetry_topic && (!cJSON_IsString(telemetry_topic) ||
+                            telemetry_topic->valuestring[0] == '\0' ||
+                            strlen(telemetry_topic->valuestring) >= MAX_TOPIC_LENGTH)) {
+        cJSON_Delete(request_json);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST,
+                                  "telemetry_topic must be a non-empty string under 128 characters");
+    }
+    cJSON *telemetry_qos = cJSON_GetObjectItem(request_json, "telemetry_qos");
+    if (telemetry_qos && (!cJSON_IsNumber(telemetry_qos) ||
+                          telemetry_qos->valueint < 0 || telemetry_qos->valueint > 2)) {
+        cJSON_Delete(request_json);
+        return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "telemetry_qos must be 0, 1, or 2");
     }
 
     // Get current configuration
@@ -542,8 +578,8 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
     // Update topic configuration if provided
     cJSON *topics = cJSON_GetObjectItem(request_json, "topics");
     cJSON *qos = cJSON_GetObjectItem(request_json, "qos");
-    
-    if (topics || qos || report_content) {
+
+    if (topics || qos || report_content || telemetry_enabled || telemetry_topic || telemetry_qos) {
         mqtt_service_topic_config_t topic_config;
         result = mqtt_service_get_topic_config(&topic_config);
         if (result == AICAM_OK) {
@@ -580,10 +616,22 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
             }
             
             // Note: auto_subscribe and message_config are not exposed in GET handler
-            
+
             // Update report content mode if provided (validated above)
             if (report_content) {
                 topic_config.report_content = report_content_mode;
+            }
+
+            // Update telemetry settings if provided (validated above)
+            if (telemetry_enabled) {
+                topic_config.telemetry_enabled = cJSON_IsTrue(telemetry_enabled) ? AICAM_TRUE : AICAM_FALSE;
+            }
+            if (telemetry_topic) {
+                strncpy(topic_config.telemetry_topic, telemetry_topic->valuestring, sizeof(topic_config.telemetry_topic) - 1);
+                topic_config.telemetry_topic[sizeof(topic_config.telemetry_topic) - 1] = '\0';
+            }
+            if (telemetry_qos) {
+                topic_config.telemetry_qos = (int)telemetry_qos->valueint;
             }
 
             // Apply topic configuration


### PR DESCRIPTION
## What

**AI inference can be paced to a configured rate.** Inference otherwise runs at the camera rate whenever the AI pipeline is active. A new inference_interval_ms (ai/params; 0 = every frame, or any positive ms) paces the AI node via a sliced sleep in its process callback. The NN pipe already self-regulates to min(sensor_fps, 1/inference_time), so this is a publish-rate / bandwidth control, not a way to speed up a model. Persisted through the ai_debug config chain and seeded in both AI config factories, so it survives reboot and pipeline re-init. The request value is range-checked (0..UINT32_MAX) at the API before the uint32 cast.

**AI results can be published continuously over MQTT.** Results are otherwise surfaced only on a capture trigger (the timer trigger bottoms out around a 10 s interval), and on a unit with no video client connected the AI pipeline does not run at all. A post-inference callback deep-copies the result off the pp output buffers (which are rewritten every inference) and a dedicated task serializes it with nn_create_ai_result_json (detections, poses, segmentation - the same shape as the capture report) and publishes to a persisted MAC-derived telemetry topic at the configured cadence. Config is top-level in mqtt/config (telemetry_enabled, telemetry_topic, telemetry_qos); enabling requires a non-zero inference_interval_ms. Telemetry holds the AI pipeline via a video-hub subscription (the hub refcount, so it cannot race real viewers), so it runs headless. The snapshot is invalidated on model reload before the pp metadata is freed.

Both default off; stock behavior is unchanged. Happy to relocate the config keys if you'd prefer a different home.

## Testing

Self-built with camthink/ne301-dev and OTA-flashed on an NE301 (WiFi):

- Cadence on the telemetry topic verified at 10 / 5 / 1 / 0.1 Hz with runtime interval changes; payload carries type, timestamp, frame_id, model_name, measured inference_time_ms and ai_result. Invalid intervals (negative, > uint32) are rejected; enabling telemetry requires a non-zero interval.
- Default off is a no-op (no telemetry traffic, no pacing).
- Headless (no RTSP/preview client) telemetry runs; disabling stops it and releases the pipeline.
- Model reload during telemetry does not fault and telemetry auto-resumes; capture-triggered reports and telemetry coexist on their separate topics.
- Settings persist across reboot and telemetry auto-resumes. Clean under -Werror.
