### PR TITLE
Add a compact CBOR format option for AI-result telemetry

### DIFF
--- a/Appli/Makefile
+++ b/Appli/Makefile
@@ -226,6 +226,7 @@ C_SOURCES += ../Custom/Common/Utils/generic_ymodem.c
 
 # Custom - Common/Lib - Individual libraries
 C_SOURCES += ../Custom/Common/Lib/atc/atc.c
+C_SOURCES += ../Custom/Common/Lib/cbor/cbor_enc.c
 C_SOURCES += ../Custom/Common/Lib/cJSON/cJSON.c
 C_SOURCES += ../Custom/Common/Lib/littlefs/lfs.c
 C_SOURCES += ../Custom/Common/Lib/littlefs/lfs_util.c
@@ -815,6 +816,7 @@ C_INCLUDES += -I../Custom/Common/Utils
 # Custom - Libraries
 C_INCLUDES += -I../Custom/Common/Lib
 C_INCLUDES += -I../Custom/Common/Lib/atc
+C_INCLUDES += -I../Custom/Common/Lib/cbor
 C_INCLUDES += -I../Custom/Common/Lib/cJSON
 C_INCLUDES += -I../Custom/Common/Lib/littlefs
 C_INCLUDES += -I../Custom/Common/Lib/littlefs/bd

--- a/Custom/Common/Lib/cbor/cbor_enc.c
+++ b/Custom/Common/Lib/cbor/cbor_enc.c
@@ -1,0 +1,173 @@
+/**
+ * @file cbor_enc.c
+ * @brief Minimal CBOR encoder (RFC 8949) - see cbor_enc.h
+ */
+
+#include "cbor_enc.h"
+
+#include <string.h>
+
+/* CBOR major types (RFC 8949 section 3.1), pre-shifted into the high 3 bits */
+#define CBOR_MAJOR_UINT   0x00U
+#define CBOR_MAJOR_TEXT   0x60U
+#define CBOR_MAJOR_ARRAY  0x80U
+#define CBOR_MAJOR_MAP    0xA0U
+#define CBOR_SIMPLE_NULL  0xF6U
+#define CBOR_FLOAT16      0xF9U
+
+static void cbor_put_byte(cbor_enc_t *enc, uint8_t byte)
+{
+    if (enc->overflow || enc->len >= enc->cap) {
+        enc->overflow = 1;
+        return;
+    }
+    enc->buf[enc->len++] = byte;
+}
+
+static void cbor_put_bytes(cbor_enc_t *enc, const uint8_t *bytes, size_t n)
+{
+    if (enc->overflow || n > enc->cap - enc->len) {
+        enc->overflow = 1;
+        return;
+    }
+    memcpy(&enc->buf[enc->len], bytes, n);
+    enc->len += n;
+}
+
+/**
+ * @brief Emit a major-type header with its argument in shortest form
+ */
+static void cbor_put_head(cbor_enc_t *enc, uint8_t major, uint64_t value)
+{
+    if (value < 24U) {
+        cbor_put_byte(enc, (uint8_t)(major | value));
+    } else if (value <= 0xFFU) {
+        cbor_put_byte(enc, (uint8_t)(major | 24U));
+        cbor_put_byte(enc, (uint8_t)value);
+    } else if (value <= 0xFFFFU) {
+        cbor_put_byte(enc, (uint8_t)(major | 25U));
+        cbor_put_byte(enc, (uint8_t)(value >> 8));
+        cbor_put_byte(enc, (uint8_t)value);
+    } else if (value <= 0xFFFFFFFFU) {
+        cbor_put_byte(enc, (uint8_t)(major | 26U));
+        cbor_put_byte(enc, (uint8_t)(value >> 24));
+        cbor_put_byte(enc, (uint8_t)(value >> 16));
+        cbor_put_byte(enc, (uint8_t)(value >> 8));
+        cbor_put_byte(enc, (uint8_t)value);
+    } else {
+        cbor_put_byte(enc, (uint8_t)(major | 27U));
+        for (int shift = 56; shift >= 0; shift -= 8) {
+            cbor_put_byte(enc, (uint8_t)(value >> shift));
+        }
+    }
+}
+
+/**
+ * @brief Convert float32 to IEEE 754 half with round-to-nearest-even
+ * @details Overflow becomes infinity, underflow becomes signed zero; NaN is
+ *          preserved as a quiet NaN. Rounding may carry into the exponent,
+ *          which yields the correct next-power-of-two encoding.
+ */
+static uint16_t cbor_float_to_half(float value)
+{
+    uint32_t bits;
+    memcpy(&bits, &value, sizeof(bits));
+
+    uint32_t sign = (bits >> 16) & 0x8000U;
+    uint32_t exp32 = (bits >> 23) & 0xFFU;
+    uint32_t mant = bits & 0x7FFFFFU;
+
+    if (exp32 == 0xFFU) {
+        return (uint16_t)(sign | 0x7C00U | (mant ? 0x0200U : 0U));
+    }
+
+    int32_t exp16 = (int32_t)exp32 - 127 + 15;
+    if (exp16 >= 0x1F) {
+        return (uint16_t)(sign | 0x7C00U);
+    }
+    if (exp16 <= 0) {
+        if (exp16 < -10) {
+            return (uint16_t)sign;
+        }
+        // Subnormal half: shift the full 24-bit significand into place
+        mant |= 0x800000U;
+        uint32_t shift = (uint32_t)(14 - exp16);
+        uint16_t half = (uint16_t)(mant >> shift);
+        uint32_t rem = mant & ((1U << shift) - 1U);
+        uint32_t halfway = 1U << (shift - 1U);
+        if (rem > halfway || (rem == halfway && (half & 1U))) {
+            half++;
+        }
+        return (uint16_t)(sign | half);
+    }
+
+    uint16_t half = (uint16_t)(sign | ((uint32_t)exp16 << 10) | (mant >> 13));
+    uint32_t rem = mant & 0x1FFFU;
+    if (rem > 0x1000U || (rem == 0x1000U && (half & 1U))) {
+        half++;
+    }
+    return half;
+}
+
+void cbor_enc_init(cbor_enc_t *enc, uint8_t *buf, size_t cap)
+{
+    enc->buf = buf;
+    enc->cap = buf ? cap : 0;
+    enc->len = 0;
+    enc->overflow = 0;
+}
+
+void cbor_enc_map(cbor_enc_t *enc, uint64_t pairs)
+{
+    cbor_put_head(enc, CBOR_MAJOR_MAP, pairs);
+}
+
+void cbor_enc_array(cbor_enc_t *enc, uint64_t items)
+{
+    cbor_put_head(enc, CBOR_MAJOR_ARRAY, items);
+}
+
+void cbor_enc_text(cbor_enc_t *enc, const char *s)
+{
+    cbor_enc_text_n(enc, s, s ? strlen(s) : 0);
+}
+
+void cbor_enc_text_n(cbor_enc_t *enc, const char *s, size_t n)
+{
+    if (!s) {
+        n = 0;
+    }
+    cbor_put_head(enc, CBOR_MAJOR_TEXT, n);
+    if (n > 0) {
+        cbor_put_bytes(enc, (const uint8_t *)s, n);
+    }
+}
+
+void cbor_enc_uint(cbor_enc_t *enc, uint64_t value)
+{
+    cbor_put_head(enc, CBOR_MAJOR_UINT, value);
+}
+
+void cbor_enc_null(cbor_enc_t *enc)
+{
+    cbor_put_byte(enc, CBOR_SIMPLE_NULL);
+}
+
+void cbor_enc_f16(cbor_enc_t *enc, float value)
+{
+    uint16_t half = cbor_float_to_half(value);
+    cbor_put_byte(enc, CBOR_FLOAT16);
+    cbor_put_byte(enc, (uint8_t)(half >> 8));
+    cbor_put_byte(enc, (uint8_t)half);
+}
+
+int cbor_enc_finish(const cbor_enc_t *enc, size_t *out_len)
+{
+    if (enc->overflow) {
+        return -1;
+    }
+    if (out_len) {
+        *out_len = enc->len;
+    }
+    return 0;
+}

--- a/Custom/Common/Lib/cbor/cbor_enc.h
+++ b/Custom/Common/Lib/cbor/cbor_enc.h
@@ -1,0 +1,92 @@
+/**
+ * @file cbor_enc.h
+ * @brief Minimal CBOR encoder (RFC 8949)
+ * @details Encode-only, definite-length subset used for compact telemetry
+ *          payloads: maps, arrays, text strings, unsigned integers, null,
+ *          and IEEE 754 half-precision floats. Writes are bounds-checked
+ *          against a caller-owned buffer with a sticky overflow flag, so a
+ *          whole document can be emitted before a single error check.
+ *          No dynamic allocation, no decoder.
+ */
+
+#ifndef CBOR_ENC_H
+#define CBOR_ENC_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Encoder state over a caller-owned output buffer
+ */
+typedef struct {
+    uint8_t *buf;                  // Output buffer (caller-owned)
+    size_t cap;                    // Buffer capacity in bytes
+    size_t len;                    // Bytes written so far
+    uint8_t overflow;              // Sticky flag: a write did not fit
+} cbor_enc_t;
+
+/**
+ * @brief Initialize an encoder over a buffer
+ * @param enc Encoder state
+ * @param buf Output buffer (may be NULL only if cap is 0)
+ * @param cap Buffer capacity in bytes
+ */
+void cbor_enc_init(cbor_enc_t *enc, uint8_t *buf, size_t cap);
+
+/**
+ * @brief Emit a definite-length map header
+ * @param pairs Number of key/value pairs that will follow
+ */
+void cbor_enc_map(cbor_enc_t *enc, uint64_t pairs);
+
+/**
+ * @brief Emit a definite-length array header
+ * @param items Number of items that will follow
+ */
+void cbor_enc_array(cbor_enc_t *enc, uint64_t items);
+
+/**
+ * @brief Emit a text string (UTF-8 expected, not validated)
+ */
+void cbor_enc_text(cbor_enc_t *enc, const char *s);
+
+/**
+ * @brief Emit the first n bytes of a text string
+ */
+void cbor_enc_text_n(cbor_enc_t *enc, const char *s, size_t n);
+
+/**
+ * @brief Emit an unsigned integer (shortest form)
+ */
+void cbor_enc_uint(cbor_enc_t *enc, uint64_t value);
+
+/**
+ * @brief Emit null
+ */
+void cbor_enc_null(cbor_enc_t *enc);
+
+/**
+ * @brief Emit a float as IEEE 754 half-precision (0xF9 + 2 bytes)
+ * @details Converts with round-to-nearest-even; values exceeding half range
+ *          become infinity. Intended for values in [0,1], where the maximum
+ *          conversion error is 2^-12.
+ */
+void cbor_enc_f16(cbor_enc_t *enc, float value);
+
+/**
+ * @brief Check the document for overflow and get its length
+ * @param enc Encoder state
+ * @param out_len Receives the total bytes written (valid only on success)
+ * @return 0 when the document fit the buffer, -1 when any write overflowed
+ */
+int cbor_enc_finish(const cbor_enc_t *enc, size_t *out_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // CBOR_ENC_H

--- a/Custom/Core/System/json_config_internal.h
+++ b/Custom/Core/System/json_config_internal.h
@@ -292,6 +292,7 @@
 #define NVS_KEY_MQTT_TELEMETRY_ENABLE   "mqtt_tel_en"
 #define NVS_KEY_MQTT_TELEMETRY_TOPIC    "mqtt_t_tel"
 #define NVS_KEY_MQTT_TELEMETRY_QOS      "mqtt_q_tel"
+#define NVS_KEY_MQTT_TELEMETRY_FORMAT   "mqtt_f_tel"
  
  // Work mode configuration key names
  #define NVS_KEY_WORK_MODE           "work_mode"

--- a/Custom/Core/System/json_config_json.c
+++ b/Custom/Core/System/json_config_json.c
@@ -531,6 +531,7 @@ static void parse_mqtt_service(cJSON *json, mqtt_service_config_t *cfg)
     json_get_bool(json, "telemetry_enabled", &cfg->telemetry_enabled);
     json_get_string(json, "telemetry_topic", cfg->telemetry_topic, sizeof(cfg->telemetry_topic));
     json_get_uint8(json, "telemetry_qos", &cfg->telemetry_qos);
+    json_get_uint8(json, "telemetry_format", &cfg->telemetry_format);
 }
 
 static void parse_work_mode(cJSON *json, work_mode_config_t *cfg)
@@ -1046,6 +1047,7 @@ static cJSON *serialize_mqtt_service(const mqtt_service_config_t *cfg)
     cJSON_AddBoolToObject(json, "telemetry_enabled", cfg->telemetry_enabled);
     cJSON_AddStringToObject(json, "telemetry_topic", cfg->telemetry_topic);
     cJSON_AddNumberToObject(json, "telemetry_qos", cfg->telemetry_qos);
+    cJSON_AddNumberToObject(json, "telemetry_format", cfg->telemetry_format);
 
     return json;
 }

--- a/Custom/Core/System/json_config_mgr.c
+++ b/Custom/Core/System/json_config_mgr.c
@@ -263,7 +263,8 @@
         // Continuous AI telemetry
         .telemetry_enabled = AICAM_FALSE,
         .telemetry_topic = "aicam/data/telemetry",
-        .telemetry_qos = 0
+        .telemetry_qos = 0,
+        .telemetry_format = MQTT_TELEMETRY_FORMAT_JSON
     }
  };
 

--- a/Custom/Core/System/json_config_mgr.h
+++ b/Custom/Core/System/json_config_mgr.h
@@ -356,7 +356,18 @@ typedef struct {
     aicam_bool_t telemetry_enabled;              // Publish AI results continuously
     char telemetry_topic[MAX_TOPIC_LENGTH];      // Telemetry topic
     uint8_t telemetry_qos;                       // Telemetry QoS (0-2)
+    uint8_t telemetry_format;                    // Payload format (mqtt_telemetry_format_t)
 } mqtt_service_config_t;
+
+/**
+ * @brief Continuous AI telemetry payload format
+ * @note Consumers distinguish the payloads on the wire by the first byte:
+ *       '{' (0x7B) for JSON, a CBOR map header (0xA0-0xBF) for CBOR.
+ */
+typedef enum {
+    MQTT_TELEMETRY_FORMAT_JSON = 0,              // cJSON text payload (default)
+    MQTT_TELEMETRY_FORMAT_CBOR = 1               // Compact CBOR binary payload
+} mqtt_telemetry_format_t;
 
 /** Stored in image_config_t.isp_mode — built-in profiles vs NVS-backed custom IQ. */
 #define IMAGE_ISP_MODE_OUTDOOR  0u   /* default */

--- a/Custom/Core/System/json_config_nvs.c
+++ b/Custom/Core/System/json_config_nvs.c
@@ -1200,6 +1200,12 @@ aicam_result_t json_config_save_mqtt_service_config_to_nvs(const mqtt_service_co
         result = telemetry_result;
     }
 
+    telemetry_result = json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_FORMAT, config->telemetry_format);
+    if (telemetry_result != AICAM_OK) {
+        LOG_CORE_ERROR("Failed to save MQTT telemetry format to NVS");
+        result = telemetry_result;
+    }
+
     LOG_CORE_INFO("MQTT full service configuration saved to NVS successfully");
     return result;
 }
@@ -2315,6 +2321,12 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
     else
         json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_QOS, config->mqtt_service.telemetry_qos);
 
+    result = json_config_nvs_read_uint8(NVS_KEY_MQTT_TELEMETRY_FORMAT, &temp_uint8);
+    if (result == AICAM_OK)
+        config->mqtt_service.telemetry_format = temp_uint8;
+    else
+        json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_FORMAT, config->mqtt_service.telemetry_format);
+
     // Note: RTMP config is now part of video_stream_mode, loaded below
 
     // Load work mode configuration
@@ -2510,11 +2522,13 @@ aicam_result_t json_config_load_from_nvs(aicam_global_config_t *config)
         json_config_save_to_nvs(config);  // Will call flush internally
     }
 
-    // Stored values violating a cross-field invariant are corrected in place;
-    // persist the correction so the next boot loads a consistent state
+    // Stored values violating an invariant are corrected in place; persist
+    // the corrected fields so the next boot loads a consistent state
     if (json_config_enforce_invariants(config)) {
         json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_ENABLE,
                                     config->mqtt_service.telemetry_enabled);
+        json_config_nvs_write_uint8(NVS_KEY_MQTT_TELEMETRY_FORMAT,
+                                    config->mqtt_service.telemetry_format);
     }
 
     LOG_CORE_INFO("Config loaded from NVS successfully");

--- a/Custom/Core/System/json_config_utils.c
+++ b/Custom/Core/System/json_config_utils.c
@@ -96,6 +96,8 @@
  
  aicam_bool_t json_config_enforce_invariants(aicam_global_config_t *config)
  {
+     aicam_bool_t changed = AICAM_FALSE;
+
      if (!config) {
          return AICAM_FALSE;
      }
@@ -110,10 +112,19 @@
          config->ai_debug.inference_interval_ms == 0) {
          LOG_CORE_WARN("telemetry_enabled requires inference_interval_ms > 0; disabling telemetry");
          config->mqtt_service.telemetry_enabled = 0;
-         return AICAM_TRUE;
+         changed = AICAM_TRUE;
      }
 
-     return AICAM_FALSE;
+     // telemetry_format bytes outside the known enum (a future firmware's
+     // value, or corruption) degrade to the stock JSON payload
+     if (config->mqtt_service.telemetry_format > MQTT_TELEMETRY_FORMAT_CBOR) {
+         LOG_CORE_WARN("Unknown telemetry_format %u; falling back to json",
+                       config->mqtt_service.telemetry_format);
+         config->mqtt_service.telemetry_format = MQTT_TELEMETRY_FORMAT_JSON;
+         changed = AICAM_TRUE;
+     }
+
+     return changed;
  }
  
  

--- a/Custom/Hal/nn.c
+++ b/Custom/Hal/nn.c
@@ -15,6 +15,7 @@
 #include "pp.h"
 #include "nn.h"
 #include "cJSON.h"
+#include "cbor_enc.h"
 #include "gauge_reading.h"
 #include "mpool.h"
 #include "camera.h"
@@ -1140,8 +1141,162 @@ cJSON* nn_create_ai_result_json(const nn_result_t* ai_result) {
             break;
     }
     cJSON_AddStringToObject(result_json, "type_name", type_name);
-    
+
     return result_json;
+}
+
+/* ==================== Compact CBOR encoding ==================== */
+
+// Longest class name carried in a compact payload; longer names truncate
+#define NN_CBOR_CLASS_NAME_MAX 63
+
+/**
+ * @brief Clamp to [0,1] before half-precision encoding
+ * @details The pp layer floor-clamps some MPE fields only (box and keypoint
+ *          x/y have no upper clamp); NaN maps to 0.
+ */
+static float nn_cbor_clamp01(float value) {
+    if (!(value > 0.0f)) return 0.0f;
+    if (value > 1.0f) return 1.0f;
+    return value;
+}
+
+static void nn_cbor_put_class(cbor_enc_t* enc, const char* class_name, const char* fallback) {
+    const char* name = class_name ? class_name : fallback;
+    size_t len = strlen(name);
+    if (len > NN_CBOR_CLASS_NAME_MAX) {
+        len = NN_CBOR_CLASS_NAME_MAX;
+        // Never cut a multi-byte UTF-8 sequence: RFC 8949 text strings must be
+        // valid UTF-8, and strict decoders reject the whole document otherwise
+        while (len > 0 && ((unsigned char)name[len] & 0xC0U) == 0x80U) {
+            len--;
+        }
+    }
+    cbor_enc_text(enc, "c");
+    cbor_enc_text_n(enc, name, len);
+}
+
+static void nn_cbor_put_conf(cbor_enc_t* enc, float conf) {
+    cbor_enc_text(enc, "conf");
+    cbor_enc_f16(enc, nn_cbor_clamp01(conf));
+}
+
+static void nn_cbor_put_box(cbor_enc_t* enc, float x, float y, float width, float height) {
+    cbor_enc_text(enc, "box");
+    cbor_enc_array(enc, 4);
+    cbor_enc_f16(enc, nn_cbor_clamp01(x));
+    cbor_enc_f16(enc, nn_cbor_clamp01(y));
+    cbor_enc_f16(enc, nn_cbor_clamp01(width));
+    cbor_enc_f16(enc, nn_cbor_clamp01(height));
+}
+
+static void nn_cbor_put_keypoints(cbor_enc_t* enc, const keypoint_t* keypoints, uint32_t count) {
+    cbor_enc_text(enc, "kp");
+    cbor_enc_array(enc, count);
+    for (uint32_t i = 0; i < count && !enc->overflow; i++) {
+        cbor_enc_array(enc, 3);
+        cbor_enc_f16(enc, nn_cbor_clamp01(keypoints[i].x));
+        cbor_enc_f16(enc, nn_cbor_clamp01(keypoints[i].y));
+        cbor_enc_f16(enc, nn_cbor_clamp01(keypoints[i].conf));
+    }
+}
+
+/**
+ * @brief Encode AI result as a compact CBOR map (see nn.h)
+ * @details Map shape mirrors the JSON serializer's dispatch: {"type": N} plus
+ *          one kind-specific key (OD "det", MPE/SPE "poses", ISEG "seg");
+ *          unknown kinds carry {"type": N} alone. Counts and pointers in the
+ *          result are trusted exactly as nn_create_ai_result_json trusts them
+ *          - the caller guarantees they match their backing allocations.
+ *          Loops stop early once the output buffer overflows.
+ */
+int nn_encode_ai_result_cbor(const nn_result_t* ai_result, uint8_t* buf, size_t cap) {
+    if (!ai_result || !buf) {
+        return -1;
+    }
+
+    cbor_enc_t enc;
+    cbor_enc_init(&enc, buf, cap);
+
+    switch (ai_result->type) {
+    case PP_TYPE_OD: {
+        uint8_t count = ai_result->od.detects ? ai_result->od.nb_detect : 0;
+        cbor_enc_map(&enc, 2);
+        cbor_enc_text(&enc, "type");
+        cbor_enc_uint(&enc, PP_TYPE_OD);
+        cbor_enc_text(&enc, "det");
+        cbor_enc_array(&enc, count);
+        for (uint8_t i = 0; i < count && !enc.overflow; i++) {
+            const od_detect_t* detect = &ai_result->od.detects[i];
+            cbor_enc_map(&enc, 3);
+            nn_cbor_put_class(&enc, detect->class_name, "");
+            nn_cbor_put_conf(&enc, detect->conf);
+            nn_cbor_put_box(&enc, detect->x, detect->y, detect->width, detect->height);
+        }
+        break;
+    }
+    case PP_TYPE_MPE: {
+        uint8_t count = ai_result->mpe.detects ? ai_result->mpe.nb_detect : 0;
+        cbor_enc_map(&enc, 2);
+        cbor_enc_text(&enc, "type");
+        cbor_enc_uint(&enc, PP_TYPE_MPE);
+        cbor_enc_text(&enc, "poses");
+        cbor_enc_array(&enc, count);
+        for (uint8_t i = 0; i < count && !enc.overflow; i++) {
+            const mpe_detect_t* detect = &ai_result->mpe.detects[i];
+            // Same inline-array bound as the JSON serializer's keypoint loop
+            uint32_t nb_kp = detect->nb_keypoints < 33 ? detect->nb_keypoints : 33;
+            cbor_enc_map(&enc, 4);
+            nn_cbor_put_class(&enc, detect->class_name, "person");
+            nn_cbor_put_conf(&enc, detect->conf);
+            nn_cbor_put_box(&enc, detect->x, detect->y, detect->width, detect->height);
+            nn_cbor_put_keypoints(&enc, detect->keypoints, nb_kp);
+        }
+        break;
+    }
+    case PP_TYPE_SPE: {
+        int have_pose = (ai_result->spe.keypoints != NULL && ai_result->spe.nb_keypoints > 0);
+        cbor_enc_map(&enc, 2);
+        cbor_enc_text(&enc, "type");
+        cbor_enc_uint(&enc, PP_TYPE_SPE);
+        cbor_enc_text(&enc, "poses");
+        cbor_enc_array(&enc, have_pose ? 1 : 0);
+        if (have_pose) {
+            cbor_enc_map(&enc, 1);
+            nn_cbor_put_keypoints(&enc, ai_result->spe.keypoints, ai_result->spe.nb_keypoints);
+        }
+        break;
+    }
+    case PP_TYPE_ISEG: {
+        uint8_t count = ai_result->iseg.detects ? ai_result->iseg.nb_detect : 0;
+        cbor_enc_map(&enc, 2);
+        cbor_enc_text(&enc, "type");
+        cbor_enc_uint(&enc, PP_TYPE_ISEG);
+        cbor_enc_text(&enc, "seg");
+        cbor_enc_array(&enc, count);
+        for (uint8_t i = 0; i < count && !enc.overflow; i++) {
+            const iseg_detect_t* detect = &ai_result->iseg.detects[i];
+            cbor_enc_map(&enc, 4);
+            nn_cbor_put_class(&enc, detect->class_name, "");
+            nn_cbor_put_conf(&enc, detect->conf);
+            nn_cbor_put_box(&enc, detect->x, detect->y, detect->width, detect->height);
+            cbor_enc_text(&enc, "msz");
+            cbor_enc_uint(&enc, detect->mask_size);
+        }
+        break;
+    }
+    default:
+        cbor_enc_map(&enc, 1);
+        cbor_enc_text(&enc, "type");
+        cbor_enc_uint(&enc, (uint64_t)ai_result->type);
+        break;
+    }
+
+    size_t total = 0;
+    if (cbor_enc_finish(&enc, &total) != 0) {
+        return -1;
+    }
+    return (int)total;
 }
 
 /* ==================== command processing function ==================== */

--- a/Custom/Hal/nn.c
+++ b/Custom/Hal/nn.c
@@ -1162,7 +1162,7 @@ static float nn_cbor_clamp01(float value) {
 }
 
 static void nn_cbor_put_class(cbor_enc_t* enc, const char* class_name, const char* fallback) {
-    const char* name = class_name ? class_name : fallback;
+    const char* name = class_name ? class_name : (fallback ? fallback : "");
     size_t len = strlen(name);
     if (len > NN_CBOR_CLASS_NAME_MAX) {
         len = NN_CBOR_CLASS_NAME_MAX;
@@ -1191,6 +1191,9 @@ static void nn_cbor_put_box(cbor_enc_t* enc, float x, float y, float width, floa
 }
 
 static void nn_cbor_put_keypoints(cbor_enc_t* enc, const keypoint_t* keypoints, uint32_t count) {
+    if (!keypoints) {
+        count = 0;
+    }
     cbor_enc_text(enc, "kp");
     cbor_enc_array(enc, count);
     for (uint32_t i = 0; i < count && !enc->overflow; i++) {

--- a/Custom/Hal/nn.h
+++ b/Custom/Hal/nn.h
@@ -374,4 +374,20 @@ int nn_validate_model(const uintptr_t file_ptr);
  */
 cJSON* nn_create_ai_result_json(const nn_result_t* ai_result);
 
+/**
+ * @brief Encode an AI result as a compact CBOR map (RFC 8949)
+ * @details Binary counterpart of nn_create_ai_result_json for
+ *          bandwidth-constrained publishers. Coordinates and confidences are
+ *          clamped to [0,1] and carried as half-precision floats; static
+ *          per-model metadata (keypoint names, skeleton connections) is not
+ *          carried. ISEG carries mask_size only, matching the JSON path.
+ *          The result's counts and pointers are trusted as-is (same caller
+ *          contract as nn_create_ai_result_json).
+ * @param ai_result AI result
+ * @param buf Output buffer
+ * @param cap Output buffer capacity in bytes
+ * @return Bytes written, or -1 on invalid arguments or buffer overflow
+ */
+int nn_encode_ai_result_cbor(const nn_result_t* ai_result, uint8_t* buf, size_t cap);
+
 #endif // _NN_H

--- a/Custom/Services/AI/ai_service.c
+++ b/Custom/Services/AI/ai_service.c
@@ -23,6 +23,7 @@
 #include "mqtt_service.h"
 #include "drtc.h"
 #include "common_utils.h"
+#include "cbor_enc.h"
 
 /* ==================== AI Service Context ==================== */
 
@@ -65,6 +66,10 @@ static ai_service_context_t g_ai_service = {0};
 #define AI_TELEMETRY_MAX_DETECTS    32   // matches max_detections in the AI configs
 #define AI_TELEMETRY_MAX_KEYPOINTS  64
 
+#define AI_TELEMETRY_CBOR_VERSION   1U
+// Bounds the worst-case CBOR beat (32 MPE detects x 33 keypoints) with margin
+#define AI_TELEMETRY_ENCODE_BUF_SIZE (16U * 1024U)
+
 /**
  * @brief One published telemetry beat, deep-copied at inference time
  * @details The pp module rewrites its output buffers on every inference (on
@@ -92,6 +97,7 @@ static struct {
     mpe_detect_t *mpe_detects;             // Deep-copy destination (MPE)
     spe_keypoint_t *spe_keypoints;         // Deep-copy destination (SPE)
     iseg_detect_t *iseg_detects;           // Deep-copy destination (ISEG, masks omitted)
+    uint8_t *encode_buf;                   // CBOR beat encode buffer
     video_hub_subscriber_id_t hub_sub_id;  // Hub subscription that holds the pipeline running
 } g_ai_telemetry = {0};
 
@@ -1527,11 +1533,11 @@ static void ai_telemetry_invalidate_snapshot(void)
 }
 
 /**
- * @brief Build and publish one telemetry message from the current snapshot
- * @details The snapshot mutex is held only across the JSON build; the network
- *          publish (which can block on a degraded link) runs unlocked.
+ * @brief Build and publish one JSON telemetry message from the current snapshot
+ * @details The snapshot mutex is held only across the payload build; the
+ *          network publish (which can block on a degraded link) runs unlocked.
  */
-static void ai_telemetry_publish(void)
+static void ai_telemetry_publish_json(void)
 {
     if (osMutexAcquire(g_ai_telemetry.snapshot_mutex, osWaitForever) != osOK) {
         return;
@@ -1585,6 +1591,90 @@ static void ai_telemetry_publish(void)
 }
 
 /**
+ * @brief Build and publish one compact CBOR telemetry message
+ * @details Envelope map carries the JSON wrapper's fields key-for-key:
+ *          {v, ts, fid, model, it, r}, with r the nn_encode_ai_result_cbor
+ *          output or null when the snapshot result is invalid (same
+ *          absent-result semantics as the JSON path). Same locking shape:
+ *          encode under the snapshot mutex into the telemetry-owned buffer,
+ *          publish unlocked (the publisher task is the buffer's only user).
+ */
+static void ai_telemetry_publish_cbor(void)
+{
+    if (osMutexAcquire(g_ai_telemetry.snapshot_mutex, osWaitForever) != osOK) {
+        return;
+    }
+
+    if (!g_ai_telemetry.snapshot.valid) {
+        osMutexRelease(g_ai_telemetry.snapshot_mutex);
+        return;
+    }
+
+    cbor_enc_t enc;
+    cbor_enc_init(&enc, g_ai_telemetry.encode_buf, AI_TELEMETRY_ENCODE_BUF_SIZE);
+    cbor_enc_map(&enc, 6);
+    cbor_enc_text(&enc, "v");
+    cbor_enc_uint(&enc, AI_TELEMETRY_CBOR_VERSION);
+    cbor_enc_text(&enc, "ts");
+    cbor_enc_uint(&enc, g_ai_telemetry.snapshot.timestamp_ms);
+    cbor_enc_text(&enc, "fid");
+    cbor_enc_uint(&enc, g_ai_telemetry.snapshot.frame_id);
+    cbor_enc_text(&enc, "model");
+    cbor_enc_text(&enc, g_ai_telemetry.snapshot.model_name);
+    cbor_enc_text(&enc, "it");
+    cbor_enc_uint(&enc, g_ai_telemetry.snapshot.inference_time_ms);
+    cbor_enc_text(&enc, "r");
+
+    // Same absent-result semantics as the JSON path's ai_result:null - and on
+    // a result-encode failure, rewind and publish r=null rather than dropping
+    // the beat, so consumers keep receiving a liveness signal
+    size_t result_mark = enc.len;
+    int have_result = 0;
+    if (g_ai_telemetry.snapshot.result.is_valid && !enc.overflow) {
+        int result_len = nn_encode_ai_result_cbor(&g_ai_telemetry.snapshot.result,
+                                                  enc.buf + enc.len, enc.cap - enc.len);
+        if (result_len < 0) {
+            LOG_SVC_ERROR("AI result CBOR encode failed; publishing r=null");
+            enc.len = result_mark;
+        } else {
+            enc.len += (size_t)result_len;
+            have_result = 1;
+        }
+    }
+    if (!have_result) {
+        cbor_enc_null(&enc);
+    }
+
+    size_t payload_len = 0;
+    int build_status = cbor_enc_finish(&enc, &payload_len);
+    osMutexRelease(g_ai_telemetry.snapshot_mutex);
+
+    if (build_status != 0) {
+        LOG_SVC_ERROR("Failed to encode telemetry payload");
+        return;
+    }
+
+    int publish_result = mqtt_service_publish_telemetry_raw(g_ai_telemetry.encode_buf,
+                                                            (int)payload_len);
+    if (publish_result < 0) {
+        // Expected while the broker is unreachable; QoS/backpressure errors land here too
+        LOG_SVC_DEBUG("Telemetry publish failed: %d", publish_result);
+    }
+}
+
+/**
+ * @brief Publish one telemetry beat in the configured payload format
+ */
+static void ai_telemetry_publish(void)
+{
+    if (mqtt_service_get_telemetry_format() == MQTT_TELEMETRY_FORMAT_CBOR) {
+        ai_telemetry_publish_cbor();
+    } else {
+        ai_telemetry_publish_json();
+    }
+}
+
+/**
  * @brief Telemetry publisher task
  * @details Publishes on each new-result signal; the wait timeout doubles as
  *          the pipeline-reconciliation tick so config changes apply within ~1 s.
@@ -1632,10 +1722,12 @@ static aicam_result_t ai_telemetry_init(void)
     g_ai_telemetry.mpe_detects = buffer_calloc(AI_TELEMETRY_MAX_DETECTS, sizeof(mpe_detect_t));
     g_ai_telemetry.spe_keypoints = buffer_calloc(AI_TELEMETRY_MAX_KEYPOINTS, sizeof(spe_keypoint_t));
     g_ai_telemetry.iseg_detects = buffer_calloc(AI_TELEMETRY_MAX_DETECTS, sizeof(iseg_detect_t));
+    g_ai_telemetry.encode_buf = buffer_calloc(1, AI_TELEMETRY_ENCODE_BUF_SIZE);
 
     if (!g_ai_telemetry.snapshot_mutex || !g_ai_telemetry.event_flags ||
         !g_ai_telemetry.od_detects || !g_ai_telemetry.mpe_detects ||
-        !g_ai_telemetry.spe_keypoints || !g_ai_telemetry.iseg_detects) {
+        !g_ai_telemetry.spe_keypoints || !g_ai_telemetry.iseg_detects ||
+        !g_ai_telemetry.encode_buf) {
         LOG_SVC_ERROR("Failed to allocate telemetry resources");
         ai_telemetry_deinit();
         return AICAM_ERROR_NO_MEMORY;
@@ -1753,6 +1845,10 @@ static void ai_telemetry_deinit(void)
     if (g_ai_telemetry.iseg_detects) {
         buffer_free(g_ai_telemetry.iseg_detects);
         g_ai_telemetry.iseg_detects = NULL;
+    }
+    if (g_ai_telemetry.encode_buf) {
+        buffer_free(g_ai_telemetry.encode_buf);
+        g_ai_telemetry.encode_buf = NULL;
     }
 }
 

--- a/Custom/Services/MQTT/mqtt_service.c
+++ b/Custom/Services/MQTT/mqtt_service.c
@@ -97,6 +97,7 @@ typedef struct {
     aicam_bool_t telemetry_enabled;              // Publish AI results continuously
     char telemetry_topic[MAX_TOPIC_LENGTH];      // Telemetry topic
     uint8_t telemetry_qos;                       // Telemetry QoS (0-2)
+    uint8_t telemetry_format;                    // Payload format (mqtt_telemetry_format_t)
 } mqtt_service_extended_config_t;
 
 typedef struct {
@@ -1104,6 +1105,7 @@ static aicam_result_t mqtt_config_persistent_to_runtime(const mqtt_service_confi
     runtime->telemetry_enabled = persistent->telemetry_enabled;
     strcpy(runtime->telemetry_topic, persistent->telemetry_topic);
     runtime->telemetry_qos = persistent->telemetry_qos;
+    runtime->telemetry_format = persistent->telemetry_format;
 
     return AICAM_OK;
 }
@@ -1148,6 +1150,7 @@ static aicam_result_t mqtt_config_runtime_to_persistent(const mqtt_service_exten
     persistent->telemetry_enabled = runtime->telemetry_enabled;
     strcpy(persistent->telemetry_topic, runtime->telemetry_topic);
     persistent->telemetry_qos = runtime->telemetry_qos;
+    persistent->telemetry_format = runtime->telemetry_format;
 
     return AICAM_OK;
 }
@@ -2185,6 +2188,7 @@ aicam_result_t mqtt_service_get_topic_config(mqtt_service_topic_config_t *config
     strncpy(config->telemetry_topic, g_mqtt_service.config.telemetry_topic, sizeof(config->telemetry_topic) - 1);
     config->telemetry_topic[sizeof(config->telemetry_topic) - 1] = '\0';
     config->telemetry_qos = g_mqtt_service.config.telemetry_qos;
+    config->telemetry_format = g_mqtt_service.config.telemetry_format;
 
 
     return AICAM_OK;
@@ -2233,6 +2237,7 @@ aicam_result_t mqtt_service_set_topic_config(const mqtt_service_topic_config_t *
     strncpy(g_mqtt_service.config.telemetry_topic, config->telemetry_topic, sizeof(g_mqtt_service.config.telemetry_topic) - 1);
     g_mqtt_service.config.telemetry_topic[sizeof(g_mqtt_service.config.telemetry_topic) - 1] = '\0';
     g_mqtt_service.config.telemetry_qos = config->telemetry_qos;
+    g_mqtt_service.config.telemetry_format = (uint8_t)config->telemetry_format;
 
 
     LOG_SVC_DEBUG("MQTT service topic configuration updated");
@@ -2266,6 +2271,20 @@ aicam_bool_t mqtt_service_get_telemetry_enabled(void)
 }
 
 /**
+ * @brief Get the continuous AI telemetry payload format
+ */
+mqtt_telemetry_format_t mqtt_service_get_telemetry_format(void)
+{
+    // Only the exact non-default value selects CBOR; an uninitialized service
+    // or an out-of-range stored byte degrades to the stock JSON payload
+    if (g_mqtt_service.initialized &&
+        g_mqtt_service.config.telemetry_format == MQTT_TELEMETRY_FORMAT_CBOR) {
+        return MQTT_TELEMETRY_FORMAT_CBOR;
+    }
+    return MQTT_TELEMETRY_FORMAT_JSON;
+}
+
+/**
  * @brief Publish a continuous AI telemetry message
  * @details Fire-and-forget on the configured telemetry topic/QoS. Fails fast
  *          while disconnected; callers treat failures as dropped beats.
@@ -2286,6 +2305,30 @@ int mqtt_service_publish_telemetry(const char *json_str)
 
     return mqtt_service_publish_json(g_mqtt_service.config.telemetry_topic, json_str,
                                      g_mqtt_service.config.telemetry_qos, 0);
+}
+
+/**
+ * @brief Publish a binary continuous AI telemetry message
+ * @details Same guards and topic/QoS as mqtt_service_publish_telemetry, but
+ *          the payload is length-delimited rather than a NUL-terminated
+ *          string, so binary encodings (containing 0x00 bytes) pass through.
+ */
+int mqtt_service_publish_telemetry_raw(const uint8_t *payload, int payload_len)
+{
+    if (!payload || payload_len <= 0) {
+        return MQTT_ERR_INVALID_ARG;
+    }
+
+    if (!mqtt_service_get_telemetry_enabled()) {
+        return MQTT_ERR_INVALID_STATE;
+    }
+
+    if (!mqtt_service_is_connected()) {
+        return MQTT_ERR_CONN;
+    }
+
+    return mqtt_service_publish(g_mqtt_service.config.telemetry_topic, payload, payload_len,
+                                g_mqtt_service.config.telemetry_qos, 0);
 }
 
 /* ==================== Event Management ==================== */

--- a/Custom/Services/MQTT/mqtt_service.h
+++ b/Custom/Services/MQTT/mqtt_service.h
@@ -84,6 +84,7 @@ typedef struct {
     aicam_bool_t telemetry_enabled;      // Publish AI results continuously
     char telemetry_topic[128];           // Telemetry topic
     int telemetry_qos;                   // Telemetry QoS
+    int telemetry_format;                // Payload format (mqtt_telemetry_format_t)
 } mqtt_service_topic_config_t;
 
 /* ==================== MQTT Service Interface Functions ==================== */
@@ -306,11 +307,27 @@ mqtt_report_content_t mqtt_service_get_report_content(void);
 aicam_bool_t mqtt_service_get_telemetry_enabled(void);
 
 /**
+ * @brief Get the continuous AI telemetry payload format
+ * @return MQTT_TELEMETRY_FORMAT_CBOR only when the service is initialized and
+ *         that exact format is configured; any other stored value degrades to
+ *         MQTT_TELEMETRY_FORMAT_JSON (stock behavior)
+ */
+mqtt_telemetry_format_t mqtt_service_get_telemetry_format(void);
+
+/**
  * @brief Publish a continuous AI telemetry message to the telemetry topic
  * @param json_str Pre-built JSON payload
  * @return int Message ID or error code (fails fast while disconnected)
  */
 int mqtt_service_publish_telemetry(const char *json_str);
+
+/**
+ * @brief Publish a binary continuous AI telemetry message
+ * @param payload Encoded payload bytes (may contain 0x00)
+ * @param payload_len Payload length in bytes
+ * @return int Message ID or error code (fails fast while disconnected)
+ */
+int mqtt_service_publish_telemetry_raw(const uint8_t *payload, int payload_len);
 
 /* ==================== Event Management ==================== */
 

--- a/Custom/Services/Web/api/api_mqtt_module.c
+++ b/Custom/Services/Web/api/api_mqtt_module.c
@@ -322,6 +322,8 @@ static aicam_result_t mqtt_config_get_handler(http_handler_context_t* ctx)
         cJSON_AddBoolToObject(response_json, "telemetry_enabled", topic_config.telemetry_enabled);
         cJSON_AddStringToObject(response_json, "telemetry_topic", topic_config.telemetry_topic);
         cJSON_AddNumberToObject(response_json, "telemetry_qos", topic_config.telemetry_qos);
+        cJSON_AddStringToObject(response_json, "telemetry_format",
+                                topic_config.telemetry_format == MQTT_TELEMETRY_FORMAT_CBOR ? "cbor" : "json");
 
 
         //cJSON *auto_subscribe = cJSON_CreateObject();
@@ -422,6 +424,19 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
                           telemetry_qos->valueint < 0 || telemetry_qos->valueint > 2)) {
         cJSON_Delete(request_json);
         return api_response_error(ctx, API_ERROR_INVALID_REQUEST, "telemetry_qos must be 0, 1, or 2");
+    }
+    cJSON *telemetry_format = cJSON_GetObjectItem(request_json, "telemetry_format");
+    int telemetry_format_value = MQTT_TELEMETRY_FORMAT_JSON;
+    if (telemetry_format) {
+        if (cJSON_IsString(telemetry_format) && strcmp(telemetry_format->valuestring, "json") == 0) {
+            telemetry_format_value = MQTT_TELEMETRY_FORMAT_JSON;
+        } else if (cJSON_IsString(telemetry_format) && strcmp(telemetry_format->valuestring, "cbor") == 0) {
+            telemetry_format_value = MQTT_TELEMETRY_FORMAT_CBOR;
+        } else {
+            cJSON_Delete(request_json);
+            return api_response_error(ctx, API_ERROR_INVALID_REQUEST,
+                                      "telemetry_format must be 'json' or 'cbor'");
+        }
     }
 
     // Get current configuration
@@ -579,7 +594,7 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
     cJSON *topics = cJSON_GetObjectItem(request_json, "topics");
     cJSON *qos = cJSON_GetObjectItem(request_json, "qos");
 
-    if (topics || qos || report_content || telemetry_enabled || telemetry_topic || telemetry_qos) {
+    if (topics || qos || report_content || telemetry_enabled || telemetry_topic || telemetry_qos || telemetry_format) {
         mqtt_service_topic_config_t topic_config;
         result = mqtt_service_get_topic_config(&topic_config);
         if (result == AICAM_OK) {
@@ -632,6 +647,9 @@ static aicam_result_t mqtt_config_set_handler(http_handler_context_t* ctx)
             }
             if (telemetry_qos) {
                 topic_config.telemetry_qos = (int)telemetry_qos->valueint;
+            }
+            if (telemetry_format) {
+                topic_config.telemetry_format = telemetry_format_value;
             }
 
             // Apply topic configuration


### PR DESCRIPTION
## Why

The continuous AI-result telemetry path serializes every beat with cJSON.
cJSON prints each normalized coordinate to full double precision (e.g.
0.30000001192092896), and every beat also repeats per-keypoint indices and
names, the skeleton connection list, and empty mirror arrays - all constant
for a loaded model. A single-pose beat is ~2.3 KB and a multi-pose beat at
the model's 10-detection limit is ~25 KB (the outer rows below). Run that at
a few Hz around the clock across a fleet and the telemetry stream, not the
occasional image, is what drives the data volume. On a cellular or metered
link that becomes the recurring bill, and on a battery unit it means more
time spent with the radio on.

This adds an opt-in compact encoding of the same beat. Measured on device,
identical scenes:

| beat            | JSON      | CBOR    | ratio |
|-----------------|-----------|---------|-------|
| empty scene     |     164 B |    79 B |  2.1x |
| single pose     |   2,313 B |   277 B |  8.3x |
| multi-pose (10) |  25,433 B | 2,182 B | 11.6x |

## What

`telemetry_format` in mqtt/config selects `"json"` (default, existing
payload byte-for-byte) or `"cbor"` (RFC 8949). The CBOR envelope carries the
same fields as the JSON wrapper (`v`, `ts`, `fid`, `model`, `it`, `r`), and
`r` is either null or a `{"type": N}` map plus one kind-specific key, `det`
for OD, `poses` for MPE and SPE, and `seg` for ISEG. All coordinates and
confidences are half-precision floats in [0,1]. The encoder handles every
current result kind and degrades unknown future ones to `{"type": N}`, sits
beside the existing JSON serializer, and adds no third-party code (+4.8 KB
flash, no static RAM). Producing a beat is lighter than the JSON path too,
since it writes fixed-width bytes into a preallocated buffer rather than
building the payload through cJSON's per-field allocations and
number-to-text formatting.

The saving compounds with on-device buffering for flaky links, a natural
next step for a future PR to cover. A smaller beat takes less flash as well
as less airtime, so proportionally more telemetry survives an offline
stretch and replaying it in batches stays cheap.

The default is JSON, and stock behavior is byte-identical. A camera that is
never switched publishes exactly what it does today on the same topic, so
existing integrations need no changes. CBOR is per-camera opt-in, and a
consumer only handles it if you turn it on. When you do, the first payload
byte tells the two apart, `{` (0x7B) for JSON and a CBOR map header
(0xA0-0xBF) for the compact form, with the `v` field carrying its version.
Decoding is a first-byte check plus a single `cbor2.loads` call in any CBOR
library, and the values come back as plain floats.

## Testing

Flash-tested on an NE301 (build off this branch), local broker, every beat
wire-verified with the reference decoder:

- Stock regression: field absent / `"json"` -> beats byte-identical to
  today; format persists across reboot.
- Runtime switching: `json` <-> `cbor` flips apply on the next beat, whole
  beats in one format, no tearing, including under load.
- Fidelity: half-float values round-trip within 2^-12 of the JSON values
  for the same scenes (well under the int8 models' own 1/255 grid).
- Every result kind: OD, MPE (including a 10-detection frame), SPE
  (single pose), and empty/null beats.
- Validation: unknown format strings and non-strings rejected (400);
  unknown stored values normalize to `"json"` on NVS load and config
  import.
- Robustness: QoS 1 binary payloads; capture-report coexistence (report on
  its own topic, uninterrupted); model reload during live CBOR telemetry
  (auto-resumes); 10-minute soak at max cadence (2,272 beats, zero drops,
  stable inference times).
