### PR TITLE
fix(web): stabilize live preview, wifi reconnect polling & FSBL burn flow

### DIFF
--- a/Web/package.json
+++ b/Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact-app",
   "private": true,
-  "version": "1.3.4.8",
+  "version": "1.3.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Web/src/components/wifi-reload-mask.tsx
+++ b/Web/src/components/wifi-reload-mask.tsx
@@ -3,32 +3,33 @@ import { createPortal } from 'preact/compat';
 import { useLingui } from '@lingui/react';
 import Loading from "@/components/loading";
 import SvgIcon from '@/components/svg-icon';
-/** 
- * @TODO
-* - loading10s: If connection succeeds, it means reconnected, close mask
-* - If interface is still not accessible after 10s, prompt user to reconnect network 
+/**
+ * Loading mask used while the network reconnects.
+ * - While `isLoading` is true a spinner is shown (the parent is still polling the STA API).
+ * - When `isLoading` becomes false the mask switches to `maskText` (defaults to
+ *   "network disconnected"), which the parent only triggers after polling times out.
  */
 
 export default function WifiReloadMask({ loadingText, isLoading = false, maskText = '' }: {loadingText?: string, isLoading?: boolean, maskText?: string }) {
     const [showReConnectWifi, setShowReConnectWifi] = useState(false);
     const { i18n } = useLingui();
     useEffect(() => {
-        if (!isLoading) {
-            setShowReConnectWifi(true);
-        }
+        // Spinner while loading; switch to the (dis)connected message once loading ends.
+        // Reset on every change so a fresh reload starts from the spinner state.
+        setShowReConnectWifi(!isLoading);
     }, [isLoading]);
     return createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center">
             {/* Background mask */}
             <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" />
-            
+
             {/* Content area: increase z-index to avoid being blocked by mask */}
             <div className="relative z-[51] flex flex-col items-center justify-center gap-4 p-6">
                 {showReConnectWifi ? (
                     <>
                         <SvgIcon icon="wifi_off" className="w-20 h-20 text-gray-200" />
                         <div className="text-center">
-                            <p className="text-lg font-medium text-white">  
+                            <p className="text-lg font-medium text-white">
                                 {maskText || i18n._('sys.system_management.network_disconnected')}
                             </p>
                         </div>

--- a/Web/src/lib/MSE/constant.ts
+++ b/Web/src/lib/MSE/constant.ts
@@ -31,8 +31,10 @@ export const frameHeaderSize = 88
 export const specialDuration = 1 // 1 second
 export const maxDuration = 10 // 10 seconds
 
-// JMuxer feed `time` is in milliseconds (internally multiplied by 1000 for microseconds)
-export const previewFrameMs = 33; // ~30fps
+// The device preview stream is 25 fps. Keeping the MSE timeline at 40 ms per
+// frame prevents the browser from consuming the live buffer faster than frames
+// arrive over WebSocket.
+export const previewFrameMs = 40;
 export const maxFrameMs = maxDuration * 1000;
 
 // Debug switches

--- a/Web/src/lib/MSE/h264Player.ts
+++ b/Web/src/lib/MSE/h264Player.ts
@@ -118,6 +118,12 @@ export default class H264Player {
 
     private videoFrameCnt: number = 0;
 
+    private estimatedPreviewFrameMs: number = previewFrameMs;
+
+    private frameRateWindowStartMs: number = 0;
+
+    private frameRateWindowFrames: number = 0;
+
     private playerState: number = playerStateIdle;
 
     private iChannelId: number = 0;
@@ -177,6 +183,28 @@ export default class H264Player {
     private captureParts: Uint8Array[] = [];
 
     private captureTotalBytes: number = 0;
+
+    private getAdaptivePreviewFrameDuration(nowMs: number): number {
+        if (this.frameRateWindowStartMs === 0) {
+            this.frameRateWindowStartMs = nowMs;
+            this.frameRateWindowFrames = 0;
+            return Math.round(this.estimatedPreviewFrameMs);
+        }
+
+        this.frameRateWindowFrames++;
+        const elapsedMs = nowMs - this.frameRateWindowStartMs;
+        if (elapsedMs >= 1000 && this.frameRateWindowFrames >= 10) {
+            const measuredFrameMs = elapsedMs / this.frameRateWindowFrames;
+            // Accept 15-60 fps and smooth changes so WebSocket burstiness does not
+            // immediately distort the media timeline.
+            const boundedFrameMs = Math.min(1000 / 15, Math.max(1000 / 60, measuredFrameMs));
+            this.estimatedPreviewFrameMs = this.estimatedPreviewFrameMs * 0.75 + boundedFrameMs * 0.25;
+            this.frameRateWindowStartMs = nowMs;
+            this.frameRateWindowFrames = 0;
+        }
+
+        return Math.round(this.estimatedPreviewFrameMs);
+    }
 
     // Add getter method for debugging
     getCurrentTime(): number {
@@ -415,6 +443,9 @@ export default class H264Player {
         this.lastVideoTime = 0;
         this.lastSec = 0;
         this.videoFrameCnt = 0;
+        this.estimatedPreviewFrameMs = previewFrameMs;
+        this.frameRateWindowStartMs = 0;
+        this.frameRateWindowFrames = 0;
         this.packetCount = 0;
         this.packetsPerSecond = 0;
         this.lastPacketSec = 0;
@@ -512,7 +543,8 @@ export default class H264Player {
         }
 
         let duration = 0;
-        const timeUsec = Date.now() * 1000;
+        const nowMs = Date.now();
+        const timeUsec = nowMs * 1000;
         const nowSec = (timeUsec / 1000) | 0;
         if (this.lastSec !== nowSec) {
             this.lastSec = nowSec;
@@ -522,10 +554,9 @@ export default class H264Player {
 
         if (this.firstFrame === 0) {
             this.firstFrame = 1;
-            duration = previewFrameMs;
+            duration = this.getAdaptivePreviewFrameDuration(nowMs);
         } else if (!this.isPlayback) {
-            // Fixed frame interval keeps MSE timeline stable under network jitter
-            duration = previewFrameMs;
+            duration = this.getAdaptivePreviewFrameDuration(nowMs);
         } else if (this.direction === 0) {
             if (this.playSpeed >= 4 || this.playSpeed <= 0.125) {
                 duration = specialDuration * 1000;

--- a/Web/src/lib/MSE/media.ts
+++ b/Web/src/lib/MSE/media.ts
@@ -46,7 +46,11 @@ class MsMediaSource {
     private isPlayback: boolean = false; // false: preview, true: playback
 
     // Live preview latency tuning
-    private readonly LIVE_TARGET_LATENCY = 0.2;
+    private readonly LIVE_TARGET_LATENCY = 0.35;
+
+    private readonly STARTUP_BUFFER_SECONDS = 0.35;
+
+    private readonly REBUFFER_SECONDS = 0.45;
 
     private readonly LIVE_SYNC_COOLDOWN_MS = 150;
 
@@ -56,7 +60,9 @@ class MsMediaSource {
 
     private lastPlaybackCheckMs = 0;
 
-    private initSegmentAppended: boolean = false;
+    private waitingForBuffer = true;
+
+    private hasStartedPlayback = false;
 
     private boundOnVideoStall: (() => void) | null = null;
 
@@ -93,13 +99,31 @@ class MsMediaSource {
 
         const now = Date.now();
 
-        // Hard catch-up when lag exceeds 1s (prevents multi-minute drift)
-        if (bufferTime > 1) {
+        if (this.waitingForBuffer) {
+            const requiredBuffer = this.hasStartedPlayback
+                ? this.REBUFFER_SECONDS
+                : this.STARTUP_BUFFER_SECONDS;
+            if (bufferTime < requiredBuffer) return;
+
+            this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
+            this.videoElement.playbackRate = 1;
+            this.waitingForBuffer = false;
+            this.videoElement.play();
+            if (!this.hasStartedPlayback) {
+                this.hasStartedPlayback = true;
+                this.cb({ t: 'startPlay' });
+            }
+            return;
+        }
+
+        // Hard catch-up only for a real backlog; ordinary jitter is absorbed by
+        // the live cache instead of causing repeated seeks.
+        if (bufferTime > 1.2) {
             if (now - this.lastLiveSyncMs >= this.LIVE_SYNC_COOLDOWN_MS) {
                 this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
                 this.lastLiveSyncMs = now;
                 if (this.videoElement.paused) {
-                    void this.videoElement.play();
+                    this.videoElement.play();
                 }
             }
             if (this.videoElement.playbackRate !== 1) {
@@ -108,8 +132,8 @@ class MsMediaSource {
             return;
         }
 
-        if (bufferTime > 0.45) {
-            const rate = Math.min(1.15, 1 + (bufferTime - 0.45) * 0.15);
+        if (bufferTime > 0.55) {
+            const rate = Math.min(1.08, 1 + (bufferTime - 0.55) * 0.12);
             if (Math.abs(this.videoElement.playbackRate - rate) > 0.01) {
                 this.videoElement.playbackRate = rate;
             }
@@ -131,10 +155,15 @@ class MsMediaSource {
         const playbackStuck = timeSinceAdvance > 2000
             && Math.abs(this.videoElement.currentTime - this.lastPlaybackTime) < 0.05;
 
-        if (bufferTime > 1 || playbackStuck || this.videoElement.paused) {
+        if (playbackStuck || this.videoElement.paused) {
+            this.waitingForBuffer = true;
+        }
+
+        if (bufferTime > 1.2) {
             this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
             this.lastLiveSyncMs = now;
-            void this.videoElement.play();
+            this.waitingForBuffer = false;
+            this.videoElement.play();
         }
     }
 
@@ -380,9 +409,11 @@ class MsMediaSource {
             return;
         }
 
-        // Live preview: one fMP4 fragment per append to keep MSE timeline in sync
-        const batchSize = this.isPlayback ? len : 1;
-        const batch = this.frameBuffer.splice(0, batchSize);
+        // Drain all fragments that accumulated while SourceBuffer was busy.
+        // Appending one fragment per updateend adds enough MSE overhead for the
+        // WebSocket producer to outrun the consumer, which eventually forced the
+        // old queue policy to discard visible frames.
+        const batch = this.frameBuffer.splice(0, len);
 
         let totalSize = 0;
         for (let i = 0; i < batch.length; i += 1) {
@@ -401,10 +432,7 @@ class MsMediaSource {
         try {
             this.sourceBuffer.appendBuffer(segmentBuffer);
             this.updateend = 0;
-            if (!this.isPlayback) {
-                this.initSegmentAppended = true;
-            }
-            if (this.videoElement?.paused) {
+            if (this.isPlayback && this.videoElement?.paused) {
                 this.videoElement.style.display = "";
                 this.videoElement.play();
                 this.cb({
@@ -433,24 +461,11 @@ class MsMediaSource {
             }
         }
 
-        if (!this.isPlayback) {
-            this.frameBuffer.push(objData);
-            // Only drop stale moofs after init segment is in MSE
-            if (
-                this.initSegmentAppended
-                && this.sourceBuffer !== null
-                && this.updateend === 1
-                && this.frameBuffer.length > 12
-            ) {
-                this.frameBuffer.splice(0, this.frameBuffer.length - 6);
-            }
-        } else if (this.frameBuffer.length >= this.MAX_FRAME_BUFFER_SIZE) {
+        if (this.frameBuffer.length >= this.MAX_FRAME_BUFFER_SIZE) {
             console.warn(`Frame buffer full (${this.frameBuffer.length}), dropping oldest frames`);
             this.frameBuffer.splice(0, Math.floor(this.MAX_FRAME_BUFFER_SIZE * 0.3));
-            this.frameBuffer.push(objData);
-        } else {
-            this.frameBuffer.push(objData);
         }
+        this.frameBuffer.push(objData);
 
         if (snapshotFlag === 0) {
             this.updateSourceBuffer();
@@ -486,7 +501,10 @@ class MsMediaSource {
             this.videoElement.removeEventListener('stalled', this.boundOnVideoStall);
         }
         this.videoElement = video;
-        this.boundOnVideoStall = () => this.recoverIfNeeded();
+        this.boundOnVideoStall = () => {
+            this.waitingForBuffer = true;
+            this.recoverIfNeeded();
+        };
         video.addEventListener('waiting', this.boundOnVideoStall);
         video.addEventListener('stalled', this.boundOnVideoStall);
     }
@@ -500,6 +518,8 @@ class MsMediaSource {
         this.lastLiveSyncMs = 0;
         this.lastPlaybackTime = 0;
         this.lastPlaybackCheckMs = 0;
+        this.waitingForBuffer = true;
+        this.hasStartedPlayback = false;
         if (this.sourceBuffer && !this.sourceBuffer.updating && this.mediaSource && this.mediaSource.readyState === 'open') {
             try {
                 const { buffered } = this.sourceBuffer;
@@ -515,7 +535,6 @@ class MsMediaSource {
     }
 
     resetLivePreview(video: HTMLVideoElement): void {
-        this.initSegmentAppended = false;
         this.clearBuffer();
         if (this.mediaSource || this.initFlag !== MsMediaSource.statusIdel) {
             this.uninitMse();

--- a/Web/src/lib/MSE/videoWorker.ts
+++ b/Web/src/lib/MSE/videoWorker.ts
@@ -40,7 +40,7 @@ declare const JMuxer: {
 // @ts-expect-error: importScripts is only available in worker context and jmuxer is UMD
 importScripts('/libs/jmuxer.min.js');
 
-const jmuxer: JMuxer = new JMuxer({ fps: 30 });
+const jmuxer: JMuxer = new JMuxer({ fps: 25 });
 let animationFrameId: number | null = null;
 let jmuxerCmd: MessageEvent<VideoWorkerMessage>[] = [];
 

--- a/Web/src/pages/ImportFSBL/index.tsx
+++ b/Web/src/pages/ImportFSBL/index.tsx
@@ -4,15 +4,27 @@ import { useLingui } from '@lingui/react';
 import SvgIcon from '@/components/svg-icon';
 import systemApis from '@/services/api/system';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import WifiReloadMask from '@/components/wifi-reload-mask';
+import { toast } from 'sonner';
+import { retryFetch, sleep } from '@/utils';
+
+const ACCEPT_FILE_TYPE = {
+    'application/octet-stream': ['.bin'],
+};
+const MAX_SIZE = 1024 * 1024 * 10;
 
 export default function ImportFSBL() {
     const { i18n } = useLingui();
-    const { uploadOTAFileReq, updateOTAReq, restartDevice } = systemApis;
-    const [fsblFile, setfsblFile] = useState<File | null>(null)
+    const { uploadOTAFileReq, updateOTAReq, restartDevice, getDeviceInfoReq } = systemApis;
+    const [fsblFile, setFsblFile] = useState<File | null>(null);
+    const [uploadLoading, setUploadLoading] = useState(false);
+    const [isBurning, setIsBurning] = useState(false);
+    const [isRestarting, setIsRestarting] = useState(false);
 
     const uploadFSBL = async (file: File) => {
         try {
-            setfsblFile(file);
+            setUploadLoading(true);
             await uploadOTAFileReq(file, 'fsbl');
             await updateOTAReq({
                 filename: file.name,
@@ -20,68 +32,104 @@ export default function ImportFSBL() {
                 validate_crc32: true,
                 validate_signature: true,
                 allow_downgrade: true,
-                auto_upgrade: true
+                auto_upgrade: true,
             });
+            setFsblFile(file);
         } catch (error) {
             console.error('uploadFSBL', error);
             throw error;
+        } finally {
+            setUploadLoading(false);
         }
-    }
+    };
 
     const handleUpdate = async () => {
+        if (!fsblFile) {
+            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
+            return;
+        }
         try {
-            restartDevice({ delay_seconds: 1 });
+            setIsBurning(true);
+            setIsRestarting(true);
+            await restartDevice({ delay_seconds: 1 }, { skipErrorToast: true });
+            await sleep(8000);
+            const result = await retryFetch(
+                (signal) => getDeviceInfoReq({ skipErrorToast: true, signal }),
+                5000,
+                10,
+            );
+            if (result) {
+                toast.success(i18n._('sys.system_management.update_success'));
+            }
         } catch (error) {
             console.error('handleUpdate', error);
             throw error;
+        } finally {
+            setIsRestarting(false);
+            setIsBurning(false);
         }
-    }
+    };
 
-    const customUpload = ({ placeholder, fileName }: { placeholder: string, fileName: string }) => (
-        <div className="flex flex-col gap-2 flex-1 items-center justify-center w-full h-full rounded-md">
-            {
-                fileName ? (
-                    <div className="flex flex-col items-center gap-2">
-                        <div className="w-14 h-14 bg-gray-400 rounded-md flex items-center justify-center">
-                            <SvgIcon className="w-10 h-10" icon="file" />
-                        </div>
-                        <p className="text-sm items-center  text-wrap text-text-primary">{fileName}</p>
+    const renderUploadSlot = () => (
+        <div className="flex flex-col gap-3 flex-1 items-center justify-center w-full h-full px-4 py-4 text-center">
+            {fsblFile ? (
+                <div className="flex flex-col items-center gap-3 pointer-events-none">
+                    <div className="w-14 h-14 bg-primary/10 text-primary rounded-lg flex items-center justify-center">
+                        <SvgIcon className="w-8 h-8" icon="file" />
                     </div>
-                ) : (
-                    <div className="flex flex-col gap-2 flex-1 items-center justify-center w-full h-full">
-                        <SvgIcon className="w-10 h-10" icon="upload_single" />
-                        <p className="text-sm items-center  text-wrap text-text-secondary">{placeholder}</p>
-                    </div>
-                )
-            }
-        </div>
-    )
-    return (
-        <div className="w-full h-full flex justify-center pt-4">
-            <div className="md:max-w-xl mx-4 w-full flex flex-col gap-2">
-                <Upload
-                  className="h-50"
-                  type="customZone"
-                  slot={customUpload({ placeholder: i18n._('sys.system_management.fsbl_file'), fileName: fsblFile?.name || '' })}
-                  accept={{
-                        'application/octet-stream': ['.bin'],
-                    }}
-                  maxFiles={1}
-                  maxSize={1024 * 1024 * 10}
-                  multiple={false}
-                  onFileChange={uploadFSBL}
-                />
-
-                <div className="flex gap-2 justify-end">
-                    <Button
-                      variant="primary"
-                      className="w-1/2 md:w-auto"
-                      onClick={() => handleUpdate()}
-                    >
-                        {i18n._('sys.system_management.confirm_burn')}
-                    </Button>
+                    <p className="text-sm text-text-primary text-wrap break-all max-w-[85%]">{fsblFile.name}</p>
+                    <p className="text-xs text-text-secondary">{i18n._('common.reupload')}</p>
                 </div>
-            </div>
+            ) : (
+                <div className="flex flex-col gap-2 items-center justify-center pointer-events-none">
+                    <SvgIcon className="w-12 h-12 text-text-secondary" icon="upload_single" />
+                    <p className="text-sm text-text-secondary">{i18n._('sys.system_management.fsbl_file')}</p>
+                    <p className="text-xs text-text-secondary/70">.bin</p>
+                </div>
+            )}
+        </div>
+    );
+
+    return (
+        <div className="w-full h-full flex justify-center items-start pt-4">
+            {isBurning && (
+                <WifiReloadMask
+                  isLoading={isRestarting}
+                  loadingText={i18n._('sys.system_management.firmware_upgrade_desc')}
+                  maskText={i18n._('sys.system_management.firmware_upgrade_success')}
+                />
+            )}
+            <Card className="md:max-w-xl mx-4 w-full">
+                <CardContent className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-1">
+                        <p className="text-sm text-text-primary font-bold">{i18n._('sys.system_management.header_import_firmware')}</p>
+                        <p className="text-xs text-text-secondary">*{i18n._('sys.system_management.fsbl_file')}</p>
+                    </div>
+
+                    <Upload
+                      className="h-64 w-full"
+                      type="customZone"
+                      slot={renderUploadSlot()}
+                      accept={ACCEPT_FILE_TYPE}
+                      maxFiles={1}
+                      maxSize={MAX_SIZE}
+                      multiple={false}
+                      loading={uploadLoading}
+                      onFileChange={uploadFSBL}
+                    />
+
+                    <div className="flex gap-2 justify-end">
+                        <Button
+                          variant="primary"
+                          className="w-1/2 md:w-auto"
+                          disabled={!fsblFile || uploadLoading || isBurning}
+                          onClick={() => handleUpdate()}
+                        >
+                            {i18n._('sys.system_management.confirm_burn')}
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
         </div>
     );
 }

--- a/Web/src/pages/ImportFSBL/index.tsx
+++ b/Web/src/pages/ImportFSBL/index.tsx
@@ -18,13 +18,25 @@ export default function ImportFSBL() {
     const { i18n } = useLingui();
     const { uploadOTAFileReq, updateOTAReq, restartDevice, getDeviceInfoReq } = systemApis;
     const [fsblFile, setFsblFile] = useState<File | null>(null);
-    const [uploadLoading, setUploadLoading] = useState(false);
     const [isBurning, setIsBurning] = useState(false);
     const [isRestarting, setIsRestarting] = useState(false);
 
+    // Selecting a file only stores it locally. The actual burn starts on "confirm burn".
     const uploadFSBL = async (file: File) => {
+        setFsblFile(file);
+    };
+
+    const handleUpdate = async () => {
+        if (!fsblFile) {
+            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
+            return;
+        }
+        const file = fsblFile;
         try {
-            setUploadLoading(true);
+            setIsBurning(true);
+            setIsRestarting(true);
+            // /ota/upload writes the firmware to flash (the actual burn); upgrade-local
+            // finalizes it, then restart activates it. All of this runs on "confirm burn".
             await uploadOTAFileReq(file, 'fsbl');
             await updateOTAReq({
                 filename: file.name,
@@ -34,23 +46,6 @@ export default function ImportFSBL() {
                 allow_downgrade: true,
                 auto_upgrade: true,
             });
-            setFsblFile(file);
-        } catch (error) {
-            console.error('uploadFSBL', error);
-            throw error;
-        } finally {
-            setUploadLoading(false);
-        }
-    };
-
-    const handleUpdate = async () => {
-        if (!fsblFile) {
-            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
-            return;
-        }
-        try {
-            setIsBurning(true);
-            setIsRestarting(true);
             await restartDevice({ delay_seconds: 1 }, { skipErrorToast: true });
             await sleep(8000);
             const result = await retryFetch(
@@ -59,14 +54,13 @@ export default function ImportFSBL() {
                 10,
             );
             if (result) {
+                setIsBurning(false);
                 toast.success(i18n._('sys.system_management.update_success'));
             }
         } catch (error) {
             console.error('handleUpdate', error);
-            throw error;
         } finally {
             setIsRestarting(false);
-            setIsBurning(false);
         }
     };
 
@@ -96,7 +90,7 @@ export default function ImportFSBL() {
                 <WifiReloadMask
                   isLoading={isRestarting}
                   loadingText={i18n._('sys.system_management.firmware_upgrade_desc')}
-                  maskText={i18n._('sys.system_management.firmware_upgrade_success')}
+                  maskText={i18n._('sys.system_management.network_disconnected')}
                 />
             )}
             <Card className="md:max-w-xl mx-4 w-full">
@@ -114,7 +108,6 @@ export default function ImportFSBL() {
                       maxFiles={1}
                       maxSize={MAX_SIZE}
                       multiple={false}
-                      loading={uploadLoading}
                       onFileChange={uploadFSBL}
                     />
 
@@ -122,7 +115,7 @@ export default function ImportFSBL() {
                         <Button
                           variant="primary"
                           className="w-1/2 md:w-auto"
-                          disabled={!fsblFile || uploadLoading || isBurning}
+                          disabled={!fsblFile || isBurning}
                           onClick={() => handleUpdate()}
                         >
                             {i18n._('sys.system_management.confirm_burn')}

--- a/Web/src/pages/systemSettings/communication/wifi-network.tsx
+++ b/Web/src/pages/systemSettings/communication/wifi-network.tsx
@@ -15,7 +15,7 @@ import systemSettings from '@/services/api/systemSettings';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Input } from '@/components/ui/input';
 import WifiReloadMask from '@/components/wifi-reload-mask';
-import { sleep, retryFetch } from '@/utils';
+import { sleep } from '@/utils';
 import { useCommunicationData } from '@/store/communicationData';
 
 type WifiData = {
@@ -28,6 +28,13 @@ type WifiData = {
     is_known: boolean;
     last_connected_time: number;
 }
+
+// When refreshing/reconnecting, poll the STA interface instead of failing fast on a
+// transient 500. Only surface "network disconnected" after this timeout elapses.
+const POLL_TIMEOUT = 20000;
+const POLL_INTERVAL = 1000;
+const POLL_REQUEST_TIMEOUT = 2000;
+
 export default function WifiNetworkPage() {
     const { i18n } = useLingui();
     const isMobile = useIsMobile();
@@ -166,7 +173,7 @@ export default function WifiNetworkPage() {
                     interface: 'wl'
                 }).then(resolve).catch(reject);
             })
-            await reloadMask(setWifiFn, 3000, 3, i18n._('sys.system_management.connecting_network'));
+            await reloadMask(setWifiFn, i18n._('sys.system_management.connecting_network'));
         } catch (error) {
             console.error('handleConnectWifi', error);
         } finally {
@@ -196,7 +203,7 @@ export default function WifiNetworkPage() {
             await scanWifi();
             await sleep(3000);
         };
-        reloadMask(waitScanWifi, 3000, 3, i18n._('sys.system_management.scanning_network'));
+        reloadMask(waitScanWifi, i18n._('sys.system_management.scanning_network'));
     }
     const handleDeleteWifi = async (wifiData: WifiData) => {
         try {
@@ -207,27 +214,51 @@ export default function WifiNetworkPage() {
         }
     }
 
-    const reloadMask = async (fetchFn: () => Promise<any>, loadingTime: number, loadCount: number, _loadingText: string) => {
+    // Raw STA request used while reconnecting. It throws on failure so the poll loop
+    // below can retry, and suppresses error toasts so a reconnecting device does not
+    // spam "500" notifications on every attempt.
+    const pollNetworkSTA = async (timeoutMs: number) => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const res = await getNetworkSTAReq({ skipErrorToast: true, signal: controller.signal });
+            setCurrentWifiData(res.data);
+            setKnownWifiDataList(res.data.scan_results.known_networks);
+            setOtherWifiDataList(res.data.scan_results.unknown_networks);
+            return res;
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+
+    const reloadMask = async (fetchFn: () => Promise<any>, _loadingText: string) => {
         setLoadingText(_loadingText);
         setIsReloading(true);
         setShowWifiReloadMask(true);
-        fetchFn().then(async () => {
-            const result = await retryFetch(getNetworkSTA, loadingTime, loadCount);
-            if (result) {
-                setShowWifiReloadMask(false);
+        try {
+            await fetchFn();
+        } catch (error) {
+            console.error('reloadMask fetchFn', error);
+        }
+        // Poll the STA interface until it responds again or the timeout elapses.
+        // Only keep the "network disconnected" mask visible if polling truly times out.
+        let reconnected = false;
+        const start = Date.now();
+        /* eslint-disable no-await-in-loop -- sequential polling is intentional */
+        while (Date.now() - start < POLL_TIMEOUT) {
+            try {
+                await pollNetworkSTA(POLL_REQUEST_TIMEOUT);
+                reconnected = true;
+                break;
+            } catch {
+                await sleep(POLL_INTERVAL);
             }
-        }).catch(async (error) => {
-            if (error.status && error.status === 200) {
-                const result = await retryFetch(getNetworkSTA, loadingTime, loadCount);
-                if (result) {
-                    setShowWifiReloadMask(false);
-                }
-            }
-            throw error;
-        })
-            .finally(() => {
-                setIsReloading(false);
-            });
+        }
+        /* eslint-enable no-await-in-loop */
+        if (reconnected) {
+            setShowWifiReloadMask(false);
+        }
+        setIsReloading(false);
     }
     return (
         <div className="mt-2">

--- a/Web/src/services/api/systemSettings.ts
+++ b/Web/src/services/api/systemSettings.ts
@@ -77,7 +77,7 @@ const systemSettings = {
     prioritizeNetworkReq: (data: { interface: string }) => request.post('/api/v1/system/network/comm/prioritize', data),
 
     // wifi
-    getNetworkSTAReq: () => request.get('/api/v1/system/network/wifi/sta'),
+    getNetworkSTAReq: (config?: { skipErrorToast?: boolean; signal?: AbortSignal }) => request.get('/api/v1/system/network/wifi/sta', config),
     getAPConfigReq: () => request.get('/api/v1/system/network/wifi/ap'),
     scanWifi: () => request.post('/api/v1/system/network/wifi/scan'),
     setWifi: (data: SetWifiReq) => request.post('/api/v1/system/network/wifi', data),


### PR DESCRIPTION
## Changes
- **Live preview**: stabilize 25fps playback, fix dropped frames.
- **WiFi reconnect**: poll `/wifi/sta` instead of failing fast on a transient `500`; show "network disconnected" only after polling times out.
- **FSBL burn**: selecting a file no longer burns immediately — burn starts only on "Confirm burn"; poll the device until it comes back, show "network disconnected" only on timeout.
- Bump web version to `1.3.5.0`.