### PR TITLE
fix(web): stabilize live preview, wifi reconnect polling & FSBL burn flow

### DIFF
--- a/Web/package.json
+++ b/Web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "preact-app",
   "private": true,
-  "version": "1.5.0.1",
+  "version": "1.5.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/Web/src/components/wifi-reload-mask.tsx
+++ b/Web/src/components/wifi-reload-mask.tsx
@@ -3,32 +3,33 @@ import { createPortal } from 'preact/compat';
 import { useLingui } from '@lingui/react';
 import Loading from "@/components/loading";
 import SvgIcon from '@/components/svg-icon';
-/** 
- * @TODO
-* - loading10s: If connection succeeds, it means reconnected, close mask
-* - If interface is still not accessible after 10s, prompt user to reconnect network 
+/**
+ * Loading mask used while the network reconnects.
+ * - While `isLoading` is true a spinner is shown (the parent is still polling the STA API).
+ * - When `isLoading` becomes false the mask switches to `maskText` (defaults to
+ *   "network disconnected"), which the parent only triggers after polling times out.
  */
 
 export default function WifiReloadMask({ loadingText, isLoading = false, maskText = '' }: {loadingText?: string, isLoading?: boolean, maskText?: string }) {
     const [showReConnectWifi, setShowReConnectWifi] = useState(false);
     const { i18n } = useLingui();
     useEffect(() => {
-        if (!isLoading) {
-            setShowReConnectWifi(true);
-        }
+        // Spinner while loading; switch to the (dis)connected message once loading ends.
+        // Reset on every change so a fresh reload starts from the spinner state.
+        setShowReConnectWifi(!isLoading);
     }, [isLoading]);
     return createPortal(
         <div className="fixed inset-0 z-50 flex items-center justify-center">
             {/* Background mask */}
             <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" />
-            
+
             {/* Content area: increase z-index to avoid being blocked by mask */}
             <div className="relative z-[51] flex flex-col items-center justify-center gap-4 p-6">
                 {showReConnectWifi ? (
                     <>
                         <SvgIcon icon="wifi_off" className="w-20 h-20 text-gray-200" />
                         <div className="text-center">
-                            <p className="text-lg font-medium text-white">  
+                            <p className="text-lg font-medium text-white">
                                 {maskText || i18n._('sys.system_management.network_disconnected')}
                             </p>
                         </div>

--- a/Web/src/lib/MSE/constant.ts
+++ b/Web/src/lib/MSE/constant.ts
@@ -31,9 +31,11 @@ export const frameHeaderSize = 88
 export const specialDuration = 1 // 1 second
 export const maxDuration = 10 // 10 seconds
 
-// JMuxer feed `time` is milliseconds and is converted to microseconds internally.
-export const previewFrameMs = 1000 / 30
-export const maxFrameMs = maxDuration * 1000
+// The device preview stream is 25 fps. Keeping the MSE timeline at 40 ms per
+// frame prevents the browser from consuming the live buffer faster than frames
+// arrive over WebSocket.
+export const previewFrameMs = 40;
+export const maxFrameMs = maxDuration * 1000;
 
 // Debug switches
 export const playDebug = false
@@ -52,4 +54,4 @@ export const frameType = {
 export const codecType = {
     H264: 0x1B,
     H265: 0x48323635
-}
+} 

--- a/Web/src/lib/MSE/h264Player.ts
+++ b/Web/src/lib/MSE/h264Player.ts
@@ -138,6 +138,17 @@ export default class H264Player {
 
     private isConnected: boolean = false;
 
+    private healthCheckTimer: number | null = null;
+
+    private lastValidFrameAt: number = 0;
+
+    private connectionStartedAt: number = 0;
+
+    private lastHealthPlaybackTime: number = 0;
+
+    private playbackStallStartedAt: number = 0;
+
+    private recoveryInFlight: boolean = false;
     // private hederBits: Uint8Array = new Uint8Array(0);
 
     public packetCount: number = 0;
@@ -286,6 +297,7 @@ export default class H264Player {
 
                         const frameData = this.dealVideoData(msg.payload);
                         if (frameData) {
+                            this.lastValidFrameAt = Date.now();
                             this.packetCount++;
                             this.decoderWorker?.postMessage(frameData);
                         }
@@ -345,6 +357,7 @@ export default class H264Player {
         });
         this.videoPlayer.setVideoElement(this.videoElement);
         this.setupProgressHandler();
+        this.startHealthCheck();
         return this;
     }
 
@@ -374,6 +387,9 @@ export default class H264Player {
             await sleep(500);
         }
         this.isStarted = true;
+        this.connectionStartedAt = Date.now();
+        this.lastValidFrameAt = 0;
+        this.playbackStallStartedAt = 0;
         this.initWorkers();
         this.wsConnect(url);
         this.decodeWorker?.postMessage({ type: 'init' });
@@ -382,6 +398,7 @@ export default class H264Player {
 
     destroy(): void {
         this.stopPlay();
+        this.stopHealthCheck();
         if (this.webSocketWorker) {
             this.wsDisconnect();
             try {
@@ -432,6 +449,59 @@ export default class H264Player {
         this.isStarted = false;
     }
     
+    private startHealthCheck(): void {
+        this.stopHealthCheck();
+        this.lastHealthPlaybackTime = this.videoElement?.currentTime ?? 0;
+        this.healthCheckTimer = window.setInterval(() => {
+            if (!this.isStarted || !this.wsUrl || this.recoveryInFlight) return;
+
+            const now = Date.now();
+            if (document.visibilityState === 'hidden') {
+                this.connectionStartedAt = now;
+                this.lastValidFrameAt = this.lastValidFrameAt > 0 ? now : 0;
+                this.playbackStallStartedAt = 0;
+                return;
+            }
+
+            const referenceTime = this.lastValidFrameAt || this.connectionStartedAt;
+            const timeoutMs = this.lastValidFrameAt > 0 ? 5000 : 8000;
+            if (referenceTime > 0 && now - referenceTime >= timeoutMs) {
+                this.triggerRecovery();
+                return;
+            }
+
+            const playbackTime = this.videoElement?.currentTime ?? 0;
+            if (this.lastValidFrameAt > 0
+                && Math.abs(playbackTime - this.lastHealthPlaybackTime) < 0.01) {
+                if (this.playbackStallStartedAt === 0) this.playbackStallStartedAt = now;
+                if (now - this.playbackStallStartedAt >= 5000) this.triggerRecovery();
+            } else {
+                this.lastHealthPlaybackTime = playbackTime;
+                this.playbackStallStartedAt = 0;
+            }
+        }, 1000);
+    }
+
+    private stopHealthCheck(): void {
+        if (this.healthCheckTimer !== null) {
+            clearInterval(this.healthCheckTimer);
+            this.healthCheckTimer = null;
+        }
+    }
+
+    private triggerRecovery(): void {
+        if (this.recoveryInFlight) return;
+        this.recoveryInFlight = true;
+        this.connectionStartedAt = Date.now();
+        this.lastValidFrameAt = 0;
+        this.playbackStallStartedAt = 0;
+        this.hardRestart()
+            .catch((error) => console.error('Video stream recovery failed', error))
+            .finally(() => {
+                this.recoveryInFlight = false;
+            });
+    }
+
     /**
      * Restart video stream after model upload / device pipeline reset
      */

--- a/Web/src/lib/MSE/h264Player.ts
+++ b/Web/src/lib/MSE/h264Player.ts
@@ -118,6 +118,12 @@ export default class H264Player {
 
     private videoFrameCnt: number = 0;
 
+    private estimatedPreviewFrameMs: number = previewFrameMs;
+
+    private frameRateWindowStartMs: number = 0;
+
+    private frameRateWindowFrames: number = 0;
+
     private playerState: number = playerStateIdle;
 
     private iChannelId: number = 0;
@@ -167,10 +173,6 @@ export default class H264Player {
 
     public bandwidth: number = 0; // kBps
 
-    private progressHandler: (() => void) | null = null;
-
-    private statsIntervalId: number | null = null;
-
     // H264 raw stream capture
     private captureActive: boolean = false;
 
@@ -181,6 +183,28 @@ export default class H264Player {
     private captureParts: Uint8Array[] = [];
 
     private captureTotalBytes: number = 0;
+
+    private getAdaptivePreviewFrameDuration(nowMs: number): number {
+        if (this.frameRateWindowStartMs === 0) {
+            this.frameRateWindowStartMs = nowMs;
+            this.frameRateWindowFrames = 0;
+            return Math.round(this.estimatedPreviewFrameMs);
+        }
+
+        this.frameRateWindowFrames++;
+        const elapsedMs = nowMs - this.frameRateWindowStartMs;
+        if (elapsedMs >= 1000 && this.frameRateWindowFrames >= 10) {
+            const measuredFrameMs = elapsedMs / this.frameRateWindowFrames;
+            // Accept 15-60 fps and smooth changes so WebSocket burstiness does not
+            // immediately distort the media timeline.
+            const boundedFrameMs = Math.min(1000 / 15, Math.max(1000 / 60, measuredFrameMs));
+            this.estimatedPreviewFrameMs = this.estimatedPreviewFrameMs * 0.75 + boundedFrameMs * 0.25;
+            this.frameRateWindowStartMs = nowMs;
+            this.frameRateWindowFrames = 0;
+        }
+
+        return Math.round(this.estimatedPreviewFrameMs);
+    }
 
     // Add getter method for debugging
     getCurrentTime(): number {
@@ -256,15 +280,14 @@ export default class H264Player {
                         this.lastPacketSec = nowSec;
                         this.packetCount = 0;
                     }
-                    this.packetCount++;
 
                     if (msg.payload instanceof ArrayBuffer) {
-                        // Track total bytes for bandwidth calculation
                         this.totalBytesLoaded += msg.payload.byteLength;
 
                         const frameData = this.dealVideoData(msg.payload);
                         if (frameData) {
-                            this.decoderWorker?.postMessage(frameData, [frameData.data.buffer]);
+                            this.packetCount++;
+                            this.decoderWorker?.postMessage(frameData);
                         }
                     }
                     break;
@@ -320,7 +343,6 @@ export default class H264Player {
         this.videoPlayer = new MsMediaSource((msg: CallbackEvent) => {
             this.mediaSrcCallback(msg);
         });
-        this.videoPlayer.setPlayMode(this.isPlayback);
         this.videoPlayer.setVideoElement(this.videoElement);
         this.setupProgressHandler();
         return this;
@@ -359,7 +381,6 @@ export default class H264Player {
     }
 
     destroy(): void {
-        this.teardownProgressHandler();
         this.stopPlay();
         if (this.webSocketWorker) {
             this.wsDisconnect();
@@ -412,43 +433,67 @@ export default class H264Player {
     }
     
     /**
+     * Restart video stream after model upload / device pipeline reset
+     */
+    async hardRestart(): Promise<void> {
+        if (!this.wsUrl || !this.videoElement) return;
+
+        this.firstFrame = 0;
+        this.frameIndex = 0;
+        this.lastVideoTime = 0;
+        this.lastSec = 0;
+        this.videoFrameCnt = 0;
+        this.estimatedPreviewFrameMs = previewFrameMs;
+        this.frameRateWindowStartMs = 0;
+        this.frameRateWindowFrames = 0;
+        this.packetCount = 0;
+        this.packetsPerSecond = 0;
+        this.lastPacketSec = 0;
+        this.wsRetryCount = 3;
+
+        if (this.webSocketWorker) {
+            this.wsDisconnect();
+            await sleep(300);
+            try {
+                this.webSocketWorker.terminate();
+            } catch {
+                // ignore
+            }
+            this.webSocketWorker = null;
+        }
+
+        if (this.decoderWorker) {
+            try {
+                this.decoderWorker.postMessage({ cmd: 'stop' });
+            } catch {
+                // ignore
+            }
+            await sleep(100);
+            try {
+                this.decoderWorker.terminate();
+            } catch {
+                // ignore
+            }
+            this.decoderWorker = null;
+        }
+
+        const video = this.videoElement;
+        if (this.videoPlayer) {
+            this.videoPlayer.resetLivePreview(video);
+        }
+
+        this.isConnected = false;
+        this.isStarted = false;
+        await this.start(this.wsUrl);
+    }
+
+    /**
      * Restart video stream
      * - init websocket connection
      * - close mse buffer and feed stream to mse
      */
     async reStart(): Promise<void> {
-        if (!this.wsUrl || !this.videoElement) return;
-
-        // Disconnect if already connected
-        if (this.isConnected && this.webSocketWorker) {
-            this.wsDisconnect();
-            await sleep(500);
-        }
-
-        // Initialize workers (idempotent - will create missing ones and setup handlers)
-        this.initWorkers();
-
-        // Ensure videoPlayer exists and is initialized
-        if (!this.videoPlayer) {
-            this.creatVideoPlayer();
-        }
-
-        if (this.videoPlayer && this.videoElement) {
-            this.videoPlayer.setVideoElement(this.videoElement);
-        }
-
-        // Clear MSE buffer before restarting
-        this.videoPlayer?.clearBuffer();
-
-        // Reconnect websocket - this will start feeding data to the stream
-        this.wsConnect(this.wsUrl);
-
-        // Reinitialize decoder worker to prepare for new stream
-        this.decoderWorker?.postMessage({ type: 'init' });
-
-        // Reset state
-        this.isStarted = true;
-        this.isConnected = true;
+        await this.hardRestart();
     }
 
     videoMsgCallback(event: MessageEvent): void {
@@ -463,7 +508,6 @@ export default class H264Player {
         this.videoPlayer = new MsMediaSource((msg: CallbackEvent) => {
             this.mediaSrcCallback(msg);
         });
-        this.videoPlayer.setPlayMode(this.isPlayback);
     }
 
     initDecodeWorker(): void {
@@ -479,37 +523,46 @@ export default class H264Player {
             return false;
         }
 
-        const headerView = new DataView(frameData, 0, headSize);
-        const timestampHigh = headerView.getUint32(8, false);
-        const timestampLow = headerView.getUint32(12, false);
-        const timestamp = timestampHigh * 0x100000000 + timestampLow;
-        this.currentTime = timestamp || Math.floor(Date.now() / 1000);
+        // Timestamp at bytes 12-15 in WS frame header (big-endian seconds)
+        let timestamp = 0;
+        try {
+            timestamp = new DataView(frameData).getUint32(12, false);
+            this.currentTime = timestamp;
+        } catch (e) {
+            console.error('Error getting timestamp from offset 8:', e);
+        }
+
+        if (timestamp === 0) {
+            timestamp = Math.floor(Date.now() / 1000);
+            this.currentTime = timestamp;
+        }
 
         const h264Data = new Uint8Array(frameData, headSize);
         if (!H264Player.checkFrameData(h264Data)) {
             return false;
         }
 
+        let duration = 0;
         const nowMs = Date.now();
-        const nowSec = Math.floor(nowMs / 1000);
+        const timeUsec = nowMs * 1000;
+        const nowSec = (timeUsec / 1000) | 0;
         if (this.lastSec !== nowSec) {
             this.lastSec = nowSec;
             this.videoFrameCnt = 0;
         }
         this.videoFrameCnt++;
 
-        let duration: number;
         if (this.firstFrame === 0) {
             this.firstFrame = 1;
-            duration = previewFrameMs;
+            duration = this.getAdaptivePreviewFrameDuration(nowMs);
         } else if (!this.isPlayback) {
-            // A stable media timeline is more important than network-arrival jitter.
-            duration = previewFrameMs;
+            duration = this.getAdaptivePreviewFrameDuration(nowMs);
         } else if (this.direction === 0) {
             if (this.playSpeed >= 4 || this.playSpeed <= 0.125) {
                 duration = specialDuration * 1000;
             } else {
-                duration = Math.round((nowMs - this.lastVideoTime) / this.playSpeed);
+                duration = Math.round((timeUsec - this.lastVideoTime) / 1000);
+                duration = Math.round(duration / this.playSpeed);
                 if (duration <= 0 || duration > maxFrameMs) {
                     duration = maxFrameMs;
                 }
@@ -519,7 +572,7 @@ export default class H264Player {
         }
 
         this.frameIndex++;
-        this.lastVideoTime = nowMs;
+        this.lastVideoTime = timeUsec;
 
         if (this.captureActive) {
             this.appendH264Capture(frameData);
@@ -613,13 +666,16 @@ export default class H264Player {
         const len = h264Data.byteLength;
         if (len < 4) return false;
 
-        // Accept Annex-B payloads with either a 3-byte or 4-byte start code.
-        const scanLength = Math.min(len - 3, 64);
-        for (let i = 0; i < scanLength; i += 1) {
-            if (h264Data[i] === 0 && h264Data[i + 1] === 0) {
-                if (h264Data[i + 2] === 1) return true;
-                if (h264Data[i + 2] === 0 && h264Data[i + 3] === 1) return true;
-            }
+        // Annex-B: 00 00 01 or 00 00 00 01
+        if (h264Data[0] === 0 && h264Data[1] === 0) {
+            if (h264Data[2] === 1) return true;
+            if (len >= 4 && h264Data[2] === 0 && h264Data[3] === 1) return true;
+        }
+
+        // Fallback: non-empty payload
+        const scanLen = Math.min(len, 64);
+        for (let i = 0; i < scanLen; i += 1) {
+            if (h264Data[i] !== 0) return true;
         }
         return false;
     }
@@ -723,7 +779,6 @@ export default class H264Player {
 
     setPlayMode(opt: boolean): void {
         this.isPlayback = opt;
-        this.videoPlayer?.setPlayMode(opt);
     }
 
     /**
@@ -824,25 +879,18 @@ export default class H264Player {
     private setupProgressHandler(): void {
         if (!this.videoElement) return;
 
-        this.teardownProgressHandler();
-        this.progressHandler = () => this.onProgress();
-        this.videoElement.addEventListener('progress', this.progressHandler);
+        this.videoElement.addEventListener('progress', () => {
+            this.onProgress();
+        });
 
-        this.statsIntervalId = window.setInterval(() => {
+        // Also update stats and recover from playback stall
+        setInterval(() => {
             this.calculateBandwidth();
             this.latency = this.calculateLatency();
+            if (!this.isPlayback) {
+                this.videoPlayer?.recoverIfNeeded();
+            }
         }, 1000);
-    }
-
-    private teardownProgressHandler(): void {
-        if (this.videoElement && this.progressHandler) {
-            this.videoElement.removeEventListener('progress', this.progressHandler);
-        }
-        this.progressHandler = null;
-        if (this.statsIntervalId !== null) {
-            window.clearInterval(this.statsIntervalId);
-            this.statsIntervalId = null;
-        }
     }
 
     /**
@@ -851,7 +899,7 @@ export default class H264Player {
     private onProgress(): void {
         if (!this.videoElement) return;
 
-        // Live preview latency is controlled exclusively by MsMediaSource.
+        // Live preview: media.ts handles latency via buffer jump; avoid competing playbackRate changes
         if (!this.isPlayback) {
             this.latency = this.calculateLatency();
             return;
@@ -919,4 +967,4 @@ export default class H264Player {
     // setPlayPaused(opt: number): void {
     //     this.isPause = opt;
     // }
-}
+} 

--- a/Web/src/lib/MSE/media.ts
+++ b/Web/src/lib/MSE/media.ts
@@ -1,5 +1,3 @@
-import browser from './utils/myBrowser.js';
-
 // Type definitions
 interface FrameData {
     data: ArrayBuffer;
@@ -47,51 +45,31 @@ class MsMediaSource {
 
     private isPlayback: boolean = false; // false: preview, true: playback
 
+    // Live preview latency tuning
+    private readonly LIVE_TARGET_LATENCY = 0.35;
+
+    private readonly STARTUP_BUFFER_SECONDS = 0.35;
+
+    private readonly REBUFFER_SECONDS = 0.45;
+
+    private readonly LIVE_SYNC_COOLDOWN_MS = 150;
+
+    private lastLiveSyncMs = 0;
+
+    private lastPlaybackTime = 0;
+
+    private lastPlaybackCheckMs = 0;
+
+    private waitingForBuffer = true;
+
+    private hasStartedPlayback = false;
+
+    private boundOnVideoStall: (() => void) | null = null;
+
     // Buffer management optimization
-    private readonly MAX_FRAME_BUFFER_SIZE: number = 300; // Limit frame buffer size
+    private readonly MAX_FRAME_BUFFER_SIZE: number = 60;
 
     private readonly BUFFER_WINDOW_SIZE: number = 15; // Keep 15 seconds of buffer (Frigate strategy)
-
-    private readonly isSafari: boolean = browser.isBrowserSafari()
-        || /iPad|iPhone|iPod/.test(navigator.userAgent);
-
-    // Removing buffered ranges too frequently can make WebKit re-anchor the
-    // playhead to an older keyframe. Keep a wider window on Safari.
-    private readonly safariBufferWindowSize: number = 45;
-
-    private readonly liveTargetLatency: number = this.isSafari ? 0.6 : 0.35;
-
-    private readonly liveSoftCatchUpLatency: number = this.isSafari ? 0.9 : 0.65;
-
-    private readonly liveHardCatchUpLatency: number = this.isSafari ? 1.5 : 2;
-
-    private readonly liveSyncCooldownMs: number = 2000;
-
-    private readonly stallRecoveryDelayMs: number = this.isSafari ? 3000 : 1200;
-
-    private readonly startupMinBufferedSeconds: number = this.isSafari ? 0.45 : 0.15;
-
-    private readonly startupMinFragments: number = this.isSafari ? 14 : 3;
-
-    private lastLiveSyncMs: number = 0;
-
-    private lastPlaybackTime: number = 0;
-
-    private lastPlaybackAdvanceMs: number = Date.now();
-
-    private lastPlayheadCorrectionMs: number = 0;
-
-    private hasStartedPlayback: boolean = false;
-
-    private playRequestPending: boolean = false;
-
-    private rebuildTimerId: number | null = null;
-
-    private readonly boundVideoErrorCallback = (event: Event) => this.videoErrorCallback(event);
-
-    private readonly boundVideoStallCallback = () => this.recoverLivePreview();
-
-    private readonly boundTimeUpdateCallback = () => this.handlePlaybackTimeUpdate();
 
     constructor(cb: CallbackFunction) {
         this.cb = cb;
@@ -107,6 +85,96 @@ class MsMediaSource {
 
     static get statusDestroy(): number { return 4; }
 
+    static get skipCount(): number { return 5; } // Frame skip catch-up count
+
+    private getLiveEdge(): number {
+        if (!this.sourceBuffer || this.sourceBuffer.buffered.length === 0) return 0;
+        const { buffered } = this.sourceBuffer;
+        return buffered.end(buffered.length - 1);
+    }
+
+    private syncLivePreview(liveEdge: number, bufferTime: number): void {
+        if (!this.videoElement || this.isPlayback) return;
+        if (!Number.isFinite(bufferTime) || bufferTime < 0 || liveEdge <= 0) return;
+
+        const now = Date.now();
+
+        if (this.waitingForBuffer) {
+            const requiredBuffer = this.hasStartedPlayback
+                ? this.REBUFFER_SECONDS
+                : this.STARTUP_BUFFER_SECONDS;
+            if (bufferTime < requiredBuffer) return;
+
+            this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
+            this.videoElement.playbackRate = 1;
+            this.waitingForBuffer = false;
+            this.videoElement.play();
+            if (!this.hasStartedPlayback) {
+                this.hasStartedPlayback = true;
+                this.cb({ t: 'startPlay' });
+            }
+            return;
+        }
+
+        // Hard catch-up only for a real backlog; ordinary jitter is absorbed by
+        // the live cache instead of causing repeated seeks.
+        if (bufferTime > 1.2) {
+            if (now - this.lastLiveSyncMs >= this.LIVE_SYNC_COOLDOWN_MS) {
+                this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
+                this.lastLiveSyncMs = now;
+                if (this.videoElement.paused) {
+                    this.videoElement.play();
+                }
+            }
+            if (this.videoElement.playbackRate !== 1) {
+                this.videoElement.playbackRate = 1;
+            }
+            return;
+        }
+
+        if (bufferTime > 0.55) {
+            const rate = Math.min(1.08, 1 + (bufferTime - 0.55) * 0.12);
+            if (Math.abs(this.videoElement.playbackRate - rate) > 0.01) {
+                this.videoElement.playbackRate = rate;
+            }
+        } else if (this.videoElement.playbackRate !== 1) {
+            this.videoElement.playbackRate = 1;
+        }
+    }
+
+    /** Recover when video stalls but stream data is still arriving */
+    recoverIfNeeded(): void {
+        if (!this.videoElement || !this.sourceBuffer || this.isPlayback) return;
+
+        const liveEdge = this.getLiveEdge();
+        if (liveEdge <= 0) return;
+
+        const bufferTime = liveEdge - this.videoElement.currentTime;
+        const now = Date.now();
+        const timeSinceAdvance = now - this.lastPlaybackCheckMs;
+        const playbackStuck = timeSinceAdvance > 2000
+            && Math.abs(this.videoElement.currentTime - this.lastPlaybackTime) < 0.05;
+
+        if (playbackStuck || this.videoElement.paused) {
+            this.waitingForBuffer = true;
+        }
+
+        if (bufferTime > 1.2) {
+            this.videoElement.currentTime = Math.max(0, liveEdge - this.LIVE_TARGET_LATENCY);
+            this.lastLiveSyncMs = now;
+            this.waitingForBuffer = false;
+            this.videoElement.play();
+        }
+    }
+
+    private trackPlaybackAdvance(): void {
+        const t = this.videoElement?.currentTime ?? 0;
+        if (t !== this.lastPlaybackTime) {
+            this.lastPlaybackTime = t;
+            this.lastPlaybackCheckMs = Date.now();
+        }
+    }
+
     initMse(codec: string): boolean {
         // Unified selection of available MediaSource constructor (prefer ManagedMediaSource)
         const MediaSourceCtor = (window.ManagedMediaSource ?? window.MediaSource) as MediaSourceConstructor | undefined;
@@ -115,15 +183,16 @@ class MsMediaSource {
             return false;
         }
 
-        if (MediaSourceCtor.isTypeSupported && !MediaSourceCtor.isTypeSupported(codec)) {
-            console.error("Unsupported MIME type or codec: ", codec);
-            return false;
-        }
+        // if (!window.MediaSource.isTypeSupported(codec)) {
+        //     console.log(codec);
+        //     console.error("Unsupported MIME type or codec: ", codec);
+        //     return false;
+        // }
         this.mimeCodec = codec;
 
         try {
-            this.videoElement?.removeEventListener("error", this.boundVideoErrorCallback);
-            this.videoElement?.addEventListener("error", this.boundVideoErrorCallback);
+            // create video
+            this.videoElement?.addEventListener("error", this.videoErrorCallback.bind(this));
 
             // create mse
             this.mediaSource = new MediaSourceCtor();
@@ -135,9 +204,9 @@ class MsMediaSource {
 
             // mse event
             this.mediaSource.addEventListener("sourceopen", () => {
-                console.log("ms mse open.");
                 this.uninitSourceBuffer();
                 this.initSourceBuffer();
+                this.updateSourceBuffer();
             });
 
             this.mediaSource.addEventListener("sourceclose", () => {
@@ -197,24 +266,22 @@ class MsMediaSource {
                 return;
             }
 
-            // Preserve the <video> node before uninitMse() nulls this.videoElement
-            const video = this.videoElement;
-            const codec = this.mimeCodec;
-
+            // Mark as destroyed and notify external
             this.initFlag = MsMediaSource.statusDestroy;
             this.cb({ t: 'mseError' });
 
+            // Try to reinitialize MSE (preserve existing mimeCodec and videoElement)
+            const codec = this.mimeCodec;
+            // First completely clean up to avoid residual state
             this.uninitMse();
             this.initFlag = MsMediaSource.statusIdel;
-
-            if (codec && video) {
-                this.rebuildTimerId = window.setTimeout(() => {
-                    this.rebuildTimerId = null;
-                    // Re-bind the same video element; without this, MSE rebuilds orphaned
-                    // and the UI stays black while WS/FPS keep updating.
-                    this.setVideoElement(video);
-                    if (this.initMse(codec)) {
+            if (codec && this.videoElement) {
+                // Slight delay to avoid immediate rebuild in the same event loop as error trigger
+                setTimeout(() => {
+                    // Double check videoElement still exists before reinitializing
+                    if (this.videoElement && this.initMse(codec)) {
                         this.initFlag = MsMediaSource.statusNormal;
+                        // If there are buffered frames, continue driving playback
                         this.updateSourceBuffer();
                     } else {
                         this.initFlag = MsMediaSource.statusError;
@@ -244,54 +311,41 @@ class MsMediaSource {
 
         this.sourceBuffer = this.mediaSource.addSourceBuffer(this.mimeCodec);
         this.currentSegmentIndex = 0;
+        const curMode = this.sourceBuffer.mode;
+        if (curMode === 'segments') {
+            this.sourceBuffer.mode = 'sequence';
+        }
         
         this.sourceBuffer.addEventListener("updateend", () => {
             try {
                 if (this.sourceBuffer !== null && this.mediaSource?.readyState === 'open' && this.videoElement) {
                     const { buffered } = this.sourceBuffer;
-                    // Guard: no ranges available
                     if (buffered.length === 0) {
                         this.updateend = 1;
                         this.updateSourceBuffer();
                         return;
                     }
-                    // Clamp currentSegmentIndex
-                    if (this.currentSegmentIndex >= buffered.length) {
-                        this.currentSegmentIndex = buffered.length - 1;
-                    }
-                    this.handleTimeUpdate();
-                    this.guardMonotonicPlayhead();
+
+                    const liveEdge = buffered.end(buffered.length - 1);
+                    const { currentTime } = this.videoElement;
                     this.trackPlaybackAdvance();
-                    this.ensurePlayheadInBufferedRange();
-                    this.syncLivePreview();
-                    if (this.isPlayback) {
-                        this.startPlaybackIfReady();
+
+                    if (!this.isPlayback) {
+                        this.syncLivePreview(liveEdge, liveEdge - currentTime);
                     }
 
-                    // Keep more history on Safari because WebKit may visibly
-                    // re-anchor playback when old ranges are removed.
-                    if (!this.sourceBuffer.updating && buffered.length > 0) {
+                    // Preview: do not remove buffered ranges (removal can create gaps and freeze playback)
+                    if (this.isPlayback && !this.sourceBuffer.updating) {
                         const bufferEnd = buffered.end(buffered.length - 1);
                         const bufferStart = buffered.start(0);
-                        const bufferWindowSize = this.isSafari
-                            ? this.safariBufferWindowSize
-                            : this.BUFFER_WINDOW_SIZE;
-                        const removeEnd = bufferEnd - bufferWindowSize;
-                        const keepBehind = this.isSafari ? 10 : 2;
-                        const { currentTime } = this.videoElement;
+                        const removeEnd = bufferEnd - this.BUFFER_WINDOW_SIZE;
 
-                        // Remove only data safely behind the current playhead.
-                        if (removeEnd > bufferStart && currentTime > bufferStart + keepBehind) {
-                            const safeRemoveEnd = Math.min(removeEnd, currentTime - keepBehind);
+                        if (removeEnd > bufferStart && currentTime > bufferStart) {
+                            const safeRemoveEnd = Math.min(removeEnd, currentTime - 1);
                             if (safeRemoveEnd > bufferStart) {
                                 this.sourceBuffer.remove(bufferStart, safeRemoveEnd);
 
-                                // WebKit can move currentTime when the explicit
-                                // seekable range start changes, so let Safari
-                                // derive it from SourceBuffer.buffered.
-                                if (!this.isSafari
-                                    && this.mediaSource
-                                    && 'setLiveSeekableRange' in this.mediaSource) {
+                                if (this.mediaSource && 'setLiveSeekableRange' in this.mediaSource) {
                                     try {
                                         (this.mediaSource as any).setLiveSeekableRange(safeRemoveEnd, bufferEnd);
                                     } catch {
@@ -303,190 +357,20 @@ class MsMediaSource {
                     }
                 }
             } catch (error) {
-                console.log(error);
+                console.error(error);
             }
             this.updateend = 1;
-            if (!this.sourceBuffer?.updating) {
-                this.updateSourceBuffer();
-            }
+            this.updateSourceBuffer();
         });
 
         return 0;
     }
 
-    private getLiveEdge(): number {
-        if (!this.sourceBuffer || this.sourceBuffer.buffered.length === 0) return 0;
-        return this.sourceBuffer.buffered.end(this.sourceBuffer.buffered.length - 1);
-    }
-
-    private trackPlaybackAdvance(): void {
-        const currentTime = this.videoElement?.currentTime ?? 0;
-        if (currentTime > this.lastPlaybackTime + 0.01) {
-            this.lastPlaybackTime = currentTime;
-            this.lastPlaybackAdvanceMs = Date.now();
-        }
-    }
-
-    private isTimeBuffered(time: number, tolerance = 0.05): boolean {
-        if (!this.sourceBuffer) return false;
-        const { buffered } = this.sourceBuffer;
-        for (let i = 0; i < buffered.length; i += 1) {
-            if (time >= buffered.start(i) - tolerance && time <= buffered.end(i) + tolerance) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    /**
-     * Safari may move currentTime backwards after SourceBuffer eviction or a
-     * keyframe re-anchor. Live preview is monotonic, so restore the previous
-     * high-water mark when it is still buffered.
-     */
-    private guardMonotonicPlayhead(): void {
-        if (!this.isSafari || this.isPlayback || !this.videoElement) return;
-
-        const now = Date.now();
-        const { currentTime } = this.videoElement;
-        const movedBackwards = this.lastPlaybackTime > 0
-            && currentTime < this.lastPlaybackTime - 0.12;
-
-        if (!movedBackwards
-            || !this.isTimeBuffered(this.lastPlaybackTime)
-            || now - this.lastPlayheadCorrectionMs < 250) {
-            return;
-        }
-
-        this.videoElement.currentTime = this.lastPlaybackTime;
-        this.lastPlayheadCorrectionMs = now;
-        this.lastPlaybackAdvanceMs = now;
-    }
-
-    private handlePlaybackTimeUpdate(): void {
-        this.guardMonotonicPlayhead();
-        this.trackPlaybackAdvance();
-    }
-
-    private getBufferedDuration(): number {
-        if (!this.sourceBuffer) return 0;
-        const { buffered } = this.sourceBuffer;
-        let duration = 0;
-        for (let i = 0; i < buffered.length; i += 1) {
-            duration += buffered.end(i) - buffered.start(i);
-        }
-        return duration;
-    }
-
-    private startPlaybackIfReady(): void {
-        if (!this.videoElement || !this.sourceBuffer || this.playRequestPending) return;
-
-        const { buffered } = this.sourceBuffer;
-        if (buffered.length === 0) return;
-
-        if (!this.isPlayback
-            && !this.hasStartedPlayback
-            && this.getBufferedDuration() < this.startupMinBufferedSeconds) {
-            return;
-        }
-
-        if (!this.videoElement.paused) {
-            this.hasStartedPlayback = true;
-            return;
-        }
-
-        this.videoElement.style.display = "";
-        this.playRequestPending = true;
-        this.videoElement.play()
-            .then(() => {
-                if (!this.hasStartedPlayback) {
-                    this.hasStartedPlayback = true;
-                    this.cb({ t: 'startPlay' });
-                }
-            })
-            .catch(() => {
-                // Autoplay can be rejected until the page receives user interaction.
-            })
-            .finally(() => {
-                this.playRequestPending = false;
-            });
-    }
-
-    private syncLivePreview(forceRecovery = false): void {
-        if (!this.videoElement || !this.sourceBuffer || this.isPlayback) return;
-
-        const liveEdge = this.getLiveEdge();
-        if (liveEdge <= 0) return;
-
-        const lag = liveEdge - this.videoElement.currentTime;
-        const now = Date.now();
-        const stalled = now - this.lastPlaybackAdvanceMs > this.stallRecoveryDelayMs;
-        // A regular Safari seek can decode from the preceding keyframe and look
-        // like a rewind. Seek on Safari only as an actual stall recovery.
-        const shouldHardSync = this.isSafari
-            ? forceRecovery && stalled && lag > this.liveHardCatchUpLatency
-            : lag > this.liveHardCatchUpLatency
-                || (forceRecovery && stalled && lag > this.liveTargetLatency);
-
-        if (shouldHardSync && now - this.lastLiveSyncMs >= this.liveSyncCooldownMs) {
-            const target = Math.max(
-                this.videoElement.currentTime,
-                liveEdge - this.liveTargetLatency,
-            );
-            if (target > this.videoElement.currentTime + 0.05) {
-                this.videoElement.currentTime = target;
-                this.lastLiveSyncMs = now;
-            }
-        }
-
-        if (this.isSafari) {
-            if (this.videoElement.playbackRate !== 1) {
-                this.videoElement.playbackRate = 1;
-            }
-        } else if (lag > this.liveSoftCatchUpLatency && lag <= this.liveHardCatchUpLatency) {
-            this.videoElement.playbackRate = 1.05;
-        } else if (lag <= this.liveTargetLatency && this.videoElement.playbackRate !== 1) {
-            this.videoElement.playbackRate = 1;
-        }
-
-        this.startPlaybackIfReady();
-    }
-
-    private recoverLivePreview(): void {
-        this.syncLivePreview(true);
-    }
-
-    /**
-     * Move forward into the next buffered range when the playhead is in a real
-     * gap. Being close to the live edge is valid and must never trigger a rewind.
-     */
-    private ensurePlayheadInBufferedRange(): void {
-        if (!this.videoElement || !this.sourceBuffer) return;
-        const { buffered } = this.sourceBuffer;
-        if (buffered.length === 0) return;
-
-        const t = this.videoElement.currentTime;
-        const epsilon = 0.05;
-        for (let i = 0; i < buffered.length; i += 1) {
-            const start = buffered.start(i);
-            const end = buffered.end(i);
-            if (t >= start - epsilon && t <= end + epsilon) {
-                return;
-            }
-            if (t < start - epsilon) {
-                this.videoElement.currentTime = start + 0.01;
-                return;
-            }
-        }
-    }
-
     handleTimeUpdate(): void {
-        // Live preview uses a continuous MSE timeline — segment jumping here
-        // creates gaps and black frames on Safari. Only relevant for VOD-style ranges.
-        if (!this.isPlayback) return;
         if (!this.sourceBuffer || !this.videoElement) return;
         
         const { buffered } = this.sourceBuffer;
-        if (buffered.length === 0 || this.currentSegmentIndex === buffered.length - 1) {
+        if (buffered.length === 0 || this.currentSegmentIndex === buffered.length - 1 || this.isPlayback) {
             return;
         }
         if (buffered.length && this.currentSegmentIndex >= buffered.length) {
@@ -497,6 +381,7 @@ class MsMediaSource {
         const currentEnd = buffered.end(this.currentSegmentIndex);
         const nextStart = buffered.start(nextSegmentIndex);
 
+        // Playback mode only: advance across buffered segments
         this.currentSegmentIndex += 1;
         this.videoElement.currentTime = nextStart;
         this.sourceBuffer.remove(0, currentEnd);
@@ -519,42 +404,26 @@ class MsMediaSource {
             return;
         }
 
-        const queuedLength = this.frameBuffer.length;
-        if (queuedLength === 0) {
+        const len = this.frameBuffer.length;
+        if (len === 0) {
             return;
         }
 
-        // WebKit is prone to entering `waiting` when playback starts after only
-        // one or two fMP4 fragments. Aggregate a short first batch so the first
-        // play() call already has a decodable safety margin.
-        if (!this.isPlayback
-            && !this.hasStartedPlayback
-            && this.sourceBuffer.buffered.length === 0
-            && queuedLength < this.startupMinFragments) {
-            return;
-        }
-
-        // Keep appends small and predictable. Large burst appends are expensive
-        // on Safari and make latency corrections much more visible.
-        let batchSize: number;
-        if (this.isPlayback) {
-            batchSize = queuedLength;
-        } else if (!this.hasStartedPlayback) {
-            batchSize = Math.min(queuedLength, this.startupMinFragments + 4);
-        } else {
-            batchSize = Math.min(queuedLength, queuedLength > 12 ? 6 : 3);
-        }
-        const batch = this.frameBuffer.splice(0, batchSize);
+        // Drain all fragments that accumulated while SourceBuffer was busy.
+        // Appending one fragment per updateend adds enough MSE overhead for the
+        // WebSocket producer to outrun the consumer, which eventually forced the
+        // old queue policy to discard visible frames.
+        const batch = this.frameBuffer.splice(0, len);
 
         let totalSize = 0;
-        for (let i = 0; i < batch.length; i++) {
+        for (let i = 0; i < batch.length; i += 1) {
             totalSize += batch[i].data.byteLength;
         }
 
         const segmentBuffer = new Uint8Array(totalSize);
         let offset = 0;
 
-        for (let i = 0; i < batch.length; i++) {
+        for (let i = 0; i < batch.length; i += 1) {
             const frameData = new Uint8Array(batch[i].data);
             segmentBuffer.set(frameData, offset);
             offset += frameData.byteLength;
@@ -563,30 +432,19 @@ class MsMediaSource {
         try {
             this.sourceBuffer.appendBuffer(segmentBuffer);
             this.updateend = 0;
+            if (this.isPlayback && this.videoElement?.paused) {
+                this.videoElement.style.display = "";
+                this.videoElement.play();
+                this.cb({
+                    t: 'startPlay',
+                });
+            }
         } catch (e) {
             console.error(`appending error: [update=${this.sourceBuffer.updating}, updateend=${this.updateend}, length=${batch.length}, buffered.length=${this.sourceBuffer.buffered.length}]==>${e}`);
-            const video = this.videoElement;
-            const savedCodec = this.mimeCodec;
+            this.initFlag = MsMediaSource.statusDestroy;
             this.cb({
                 t: 'mseError',
             });
-            // Rebuild MSE attached to the same <video>; otherwise append failures leave a black screen
-            if (video && savedCodec) {
-                this.uninitMse();
-                this.initFlag = MsMediaSource.statusIdel;
-                this.setVideoElement(video);
-                this.rebuildTimerId = window.setTimeout(() => {
-                    this.rebuildTimerId = null;
-                    if (this.videoElement && this.initMse(savedCodec)) {
-                        this.initFlag = MsMediaSource.statusNormal;
-                        this.updateSourceBuffer();
-                    } else {
-                        this.initFlag = MsMediaSource.statusError;
-                    }
-                }, 300);
-            } else {
-                this.initFlag = MsMediaSource.statusDestroy;
-            }
         }
     }
 
@@ -603,14 +461,12 @@ class MsMediaSource {
             }
         }
 
-        // Buffer size limit: prevent memory overflow
         if (this.frameBuffer.length >= this.MAX_FRAME_BUFFER_SIZE) {
-            // Drop oldest frames if buffer is full (backpressure)
             console.warn(`Frame buffer full (${this.frameBuffer.length}), dropping oldest frames`);
-            this.frameBuffer.splice(0, Math.floor(this.MAX_FRAME_BUFFER_SIZE * 0.3)); // Drop 30%
+            this.frameBuffer.splice(0, Math.floor(this.MAX_FRAME_BUFFER_SIZE * 0.3));
         }
-
         this.frameBuffer.push(objData);
+
         if (snapshotFlag === 0) {
             this.updateSourceBuffer();
         }
@@ -640,19 +496,17 @@ class MsMediaSource {
     }
 
     setVideoElement(video: HTMLVideoElement): void {
-        if (this.videoElement && this.videoElement !== video) {
-            this.videoElement.removeEventListener('waiting', this.boundVideoStallCallback);
-            this.videoElement.removeEventListener('stalled', this.boundVideoStallCallback);
-            this.videoElement.removeEventListener('timeupdate', this.boundTimeUpdateCallback);
-            this.videoElement.removeEventListener('error', this.boundVideoErrorCallback);
+        if (this.videoElement && this.boundOnVideoStall) {
+            this.videoElement.removeEventListener('waiting', this.boundOnVideoStall);
+            this.videoElement.removeEventListener('stalled', this.boundOnVideoStall);
         }
         this.videoElement = video;
-        video.removeEventListener('waiting', this.boundVideoStallCallback);
-        video.removeEventListener('stalled', this.boundVideoStallCallback);
-        video.removeEventListener('timeupdate', this.boundTimeUpdateCallback);
-        video.addEventListener('waiting', this.boundVideoStallCallback);
-        video.addEventListener('stalled', this.boundVideoStallCallback);
-        video.addEventListener('timeupdate', this.boundTimeUpdateCallback);
+        this.boundOnVideoStall = () => {
+            this.waitingForBuffer = true;
+            this.recoverIfNeeded();
+        };
+        video.addEventListener('waiting', this.boundOnVideoStall);
+        video.addEventListener('stalled', this.boundOnVideoStall);
     }
 
     setPlayMode(playback: boolean): void {
@@ -660,15 +514,12 @@ class MsMediaSource {
     }
 
     clearBuffer(): void {
-        // Clear frame buffer to stop processing new frames
         this.frameBuffer = [];
         this.lastLiveSyncMs = 0;
         this.lastPlaybackTime = 0;
-        this.lastPlaybackAdvanceMs = Date.now();
-        this.lastPlayheadCorrectionMs = 0;
+        this.lastPlaybackCheckMs = 0;
+        this.waitingForBuffer = true;
         this.hasStartedPlayback = false;
-        this.playRequestPending = false;
-        // Clear source buffer if it exists and is not updating
         if (this.sourceBuffer && !this.sourceBuffer.updating && this.mediaSource && this.mediaSource.readyState === 'open') {
             try {
                 const { buffered } = this.sourceBuffer;
@@ -683,16 +534,23 @@ class MsMediaSource {
         this.currentSegmentIndex = 0;
     }
 
-    uninitMse(): void {
-        if (this.rebuildTimerId !== null) {
-            window.clearTimeout(this.rebuildTimerId);
-            this.rebuildTimerId = null;
+    resetLivePreview(video: HTMLVideoElement): void {
+        this.clearBuffer();
+        if (this.mediaSource || this.initFlag !== MsMediaSource.statusIdel) {
+            this.uninitMse();
         }
+        this.setVideoElement(video);
+        this.initFlag = MsMediaSource.statusIdel;
+    }
+
+    uninitMse(): void {
         if (this.videoElement !== null) {
-            this.videoElement.removeEventListener("error", this.boundVideoErrorCallback);
-            this.videoElement.removeEventListener('waiting', this.boundVideoStallCallback);
-            this.videoElement.removeEventListener('stalled', this.boundVideoStallCallback);
-            this.videoElement.removeEventListener('timeupdate', this.boundTimeUpdateCallback);
+            if (this.boundOnVideoStall) {
+                this.videoElement.removeEventListener('waiting', this.boundOnVideoStall);
+                this.videoElement.removeEventListener('stalled', this.boundOnVideoStall);
+                this.boundOnVideoStall = null;
+            }
+            this.videoElement.removeEventListener("error", this.videoErrorCallback);
             window.URL.revokeObjectURL(this.videoElement.src);
             this.videoElement.src = "";
         }
@@ -705,12 +563,6 @@ class MsMediaSource {
         this.updateend = 1;
         this.mimeCodec = "";
         this.initFlag = MsMediaSource.statusIdel;
-        this.lastLiveSyncMs = 0;
-        this.lastPlaybackTime = 0;
-        this.lastPlaybackAdvanceMs = Date.now();
-        this.lastPlayheadCorrectionMs = 0;
-        this.hasStartedPlayback = false;
-        this.playRequestPending = false;
     }
 }
 

--- a/Web/src/lib/MSE/media.ts
+++ b/Web/src/lib/MSE/media.ts
@@ -54,6 +54,14 @@ class MsMediaSource {
 
     private readonly LIVE_SYNC_COOLDOWN_MS = 150;
 
+    // iOS WebKit renders playbackRate catch-up unreliably, so live preview uses
+    // low-frequency seeks to the live edge and tolerates short rebuffer events.
+    private readonly IOS_LIVE_TARGET_LATENCY = 0.4;
+
+    private readonly IOS_SEEK_COOLDOWN_MS = 1000;
+
+    private readonly IOS_STALL_REBUFFER_MS = 2000;
+
     private lastLiveSyncMs = 0;
 
     private lastPlaybackTime = 0;
@@ -64,7 +72,17 @@ class MsMediaSource {
 
     private hasStartedPlayback = false;
 
+    // iOS WebKit flag (auto-detected, overridable in tests). When true the player
+    // prefers low-frequency seeks over playbackRate ramps for live catch-up.
+    private isIOSWebKit: boolean = typeof navigator !== 'undefined'
+        && (/iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (navigator.platform === 'MacIntel' && (navigator.maxTouchPoints ?? 0) > 1));
+
+    private stallStartedMs: number | null = null;
+
     private boundOnVideoStall: (() => void) | null = null;
+
+    private readonly boundVideoErrorCallback = (event: Event) => this.videoErrorCallback(event);
 
     // Buffer management optimization
     private readonly MAX_FRAME_BUFFER_SIZE: number = 60;
@@ -116,6 +134,11 @@ class MsMediaSource {
             return;
         }
 
+        if (this.isIOSWebKit) {
+            this.syncIOSLivePreview(liveEdge, bufferTime, now);
+            return;
+        }
+
         // Hard catch-up only for a real backlog; ordinary jitter is absorbed by
         // the live cache instead of causing repeated seeks.
         if (bufferTime > 1.2) {
@@ -138,6 +161,32 @@ class MsMediaSource {
                 this.videoElement.playbackRate = rate;
             }
         } else if (this.videoElement.playbackRate !== 1) {
+            this.videoElement.playbackRate = 1;
+        }
+    }
+
+    /**
+     * iOS WebKit live catch-up: seek to the live edge instead of ramping the
+     * playbackRate, and only promote a short stall to a full rebuffer once it has
+     * persisted past the tolerance window.
+     */
+    private syncIOSLivePreview(liveEdge: number, bufferTime: number, now: number): void {
+        if (!this.videoElement) return;
+
+        if (this.stallStartedMs !== null && now - this.stallStartedMs >= this.IOS_STALL_REBUFFER_MS) {
+            this.stallStartedMs = null;
+            this.waitingForBuffer = true;
+            return;
+        }
+
+        if (bufferTime > 0.55 && now - this.lastLiveSyncMs >= this.IOS_SEEK_COOLDOWN_MS) {
+            this.videoElement.currentTime = Math.max(0, liveEdge - this.IOS_LIVE_TARGET_LATENCY);
+            this.videoElement.playbackRate = 1;
+            this.lastLiveSyncMs = now;
+            this.videoElement.play();
+        }
+
+        if (this.videoElement.playbackRate !== 1) {
             this.videoElement.playbackRate = 1;
         }
     }
@@ -172,6 +221,7 @@ class MsMediaSource {
         if (t !== this.lastPlaybackTime) {
             this.lastPlaybackTime = t;
             this.lastPlaybackCheckMs = Date.now();
+            this.stallStartedMs = null;
         }
     }
 
@@ -192,7 +242,7 @@ class MsMediaSource {
 
         try {
             // create video
-            this.videoElement?.addEventListener("error", this.videoErrorCallback.bind(this));
+            this.videoElement?.addEventListener("error", this.boundVideoErrorCallback);
 
             // create mse
             this.mediaSource = new MediaSourceCtor();
@@ -272,8 +322,10 @@ class MsMediaSource {
 
             // Try to reinitialize MSE (preserve existing mimeCodec and videoElement)
             const codec = this.mimeCodec;
+            const video = this.videoElement;
             // First completely clean up to avoid residual state
             this.uninitMse();
+            if (video) this.setVideoElement(video);
             this.initFlag = MsMediaSource.statusIdel;
             if (codec && this.videoElement) {
                 // Slight delay to avoid immediate rebuild in the same event loop as error trigger
@@ -502,6 +554,12 @@ class MsMediaSource {
         }
         this.videoElement = video;
         this.boundOnVideoStall = () => {
+            if (this.isIOSWebKit) {
+                // Debounce short iOS rebuffer events; syncIOSLivePreview promotes a
+                // persistent stall to a full rebuffer after the tolerance window.
+                if (this.stallStartedMs === null) this.stallStartedMs = Date.now();
+                return;
+            }
             this.waitingForBuffer = true;
             this.recoverIfNeeded();
         };
@@ -520,6 +578,7 @@ class MsMediaSource {
         this.lastPlaybackCheckMs = 0;
         this.waitingForBuffer = true;
         this.hasStartedPlayback = false;
+        this.stallStartedMs = null;
         if (this.sourceBuffer && !this.sourceBuffer.updating && this.mediaSource && this.mediaSource.readyState === 'open') {
             try {
                 const { buffered } = this.sourceBuffer;
@@ -550,7 +609,7 @@ class MsMediaSource {
                 this.videoElement.removeEventListener('stalled', this.boundOnVideoStall);
                 this.boundOnVideoStall = null;
             }
-            this.videoElement.removeEventListener("error", this.videoErrorCallback);
+            this.videoElement.removeEventListener("error", this.boundVideoErrorCallback);
             window.URL.revokeObjectURL(this.videoElement.src);
             this.videoElement.src = "";
         }

--- a/Web/src/lib/MSE/videoWorker.ts
+++ b/Web/src/lib/MSE/videoWorker.ts
@@ -40,20 +40,43 @@ declare const JMuxer: {
 // @ts-expect-error: importScripts is only available in worker context and jmuxer is UMD
 importScripts('/libs/jmuxer.min.js');
 
-const jmuxer: JMuxer = new JMuxer();
+const jmuxer: JMuxer = new JMuxer({ fps: 25 });
+let animationFrameId: number | null = null;
+let jmuxerCmd: MessageEvent<VideoWorkerMessage>[] = [];
 
 function receiveMessage(event: MessageEvent<VideoWorkerMessage>): void {
-    const msg = event.data;
-    switch (msg.cmd) {
-        case 'stop':
-            jmuxer.destroy();
-            // eslint-disable-next-line no-restricted-globals
-            self.close();
+    if (animationFrameId === null) {
+        animationFrameId = requestAnimationFrame(dealJmuxerCmd);
+    }
+    jmuxerCmd.push(event);
+}
+
+function dealJmuxerCmd(): void {
+    while (jmuxerCmd.length > 0) {
+        const event = jmuxerCmd.shift();
+        if (event === undefined) {
             break;
-        case 'video':
-            if (msg.data) {
-                const videoBytes = msg.data instanceof Uint8Array ? msg.data : new Uint8Array(msg.data);
-                if (videoBytes.byteLength > 0) {
+        }
+        const msg = event.data;
+
+        switch (msg.cmd) {
+            case 'stop':
+                jmuxer.destroy();
+                if (animationFrameId !== null) {
+                    cancelAnimationFrame(animationFrameId);
+                    animationFrameId = null;
+                }
+                jmuxerCmd = [];
+                // eslint-disable-next-line no-restricted-globals
+                self.close();
+                return;
+            case 'video':
+                if (msg.data) {
+                    const videoBytes: Uint8Array = msg.data instanceof Uint8Array
+                        ? msg.data
+                        : new Uint8Array(msg.data);
+                    if (videoBytes.byteLength === 0) break;
+
                     jmuxer.feed({
                         video: videoBytes,
                         time: msg.videoTime,
@@ -61,11 +84,13 @@ function receiveMessage(event: MessageEvent<VideoWorkerMessage>): void {
                         userData: msg.userData,
                     });
                 }
-            }
-            break;
-        default:
-            break;
+                break;
+            default:
+                break;
+        }
     }
+
+    animationFrameId = null;
 }
 
 onmessage = receiveMessage;

--- a/Web/src/lib/MSE/websocket-init.ts
+++ b/Web/src/lib/MSE/websocket-init.ts
@@ -5,9 +5,6 @@ let currentUrl: string | null = null;
 let shouldReconnect = false;
 
 let retryCount = 0;
-const maxRetryCount = 3;
-const retryWindowMs = 60 * 1000;
-let firstRetryTime: number | null = null;
 const baseDelay = 1000; // ms
 let retryTimer: number | null = null;
  
@@ -41,6 +38,10 @@ function teardown(resetUrl = false): void {
     if (ws) {
         const socket = ws;
         ws = null;
+        socket.onopen = null;
+        socket.onclose = null;
+        socket.onerror = null;
+        socket.onmessage = null;
         safeClose(socket);
     }
 
@@ -52,27 +53,7 @@ function teardown(resetUrl = false): void {
 }
 
 function scheduleReconnect(): void {
-    if (!shouldReconnect || !currentUrl) {
-        return;
-    }
-
-    const now = Date.now();
-    
-    // If this is the first reconnection, record the timestamp
-    if (firstRetryTime === null) {
-        firstRetryTime = now;
-    }
-    
-    // Check if more than 1 minute have passed
-    if (now - firstRetryTime >= retryWindowMs) {
-        // If more than 10 minutes have passed, reset the count and timestamp
-        retryCount = 0;
-        firstRetryTime = now;
-    }
-    
-    // Check the number of reconnection attempts in the last 1 minute
-    if (retryCount >= maxRetryCount) {
-        ctx.postMessage({ type: 'close', code: 4999, reason: 'Max retries reached in 10 minutes' });
+    if (!shouldReconnect || !currentUrl || retryTimer !== null) {
         return;
     }
 
@@ -83,6 +64,7 @@ function scheduleReconnect(): void {
     clearRetryTimer();
     retryTimer = setTimeout(() => {
         attemptConnect(currentUrl!);
+        retryTimer = null;
     }, delay) as unknown as number;
 }
 
@@ -93,16 +75,18 @@ function attemptConnect(url: string): void {
         // Notify main thread: connection is starting (used to show loading UI)
         ctx.postMessage({ type: 'connecting' });
         ws = new WebSocket(url);
-        ws.binaryType = 'arraybuffer';
+        const socket = ws;
+        socket.binaryType = 'arraybuffer';
 
-        ws.onopen = () => {
+        socket.onopen = () => {
+            if (ws !== socket) return;
             retryCount = 0;
-            firstRetryTime = null; // Reset the time window
             clearRetryTimer();
             ctx.postMessage({ type: 'open' });
         };
 
-        ws.onclose = (event: CloseEvent) => {
+        socket.onclose = (event: CloseEvent) => {
+            if (ws !== socket) return;
             const wasManual = !shouldReconnect;
             teardown(!shouldReconnect);
 
@@ -111,20 +95,20 @@ function attemptConnect(url: string): void {
                 return;
             }
 
-            // 1000-1006: Normal/Strategic close does not reconnect
-            if (event.code >= 1000 && event.code <= 1005) {
+            if (event.reason === 'Connection replaced') {
                 ctx.postMessage({ type: 'close', code: event.code, reason: event.reason });
                 return;
             }
             scheduleReconnect();
         };
 
-        ws.onerror = () => {
+        socket.onerror = () => {
+            if (ws !== socket) return;
             ctx.postMessage({ type: 'error', error: 'WebSocket error' });
-            scheduleReconnect();
         };
 
-        ws.onmessage = (event: MessageEvent) => {
+        socket.onmessage = (event: MessageEvent) => {
+            if (ws !== socket) return;
             const payload = event.data;
             const message = { type: 'video-data', payload } as const;
             if (payload instanceof ArrayBuffer) {
@@ -160,7 +144,6 @@ function attemptConnect(url: string): void {
             shouldReconnect = true;
             currentUrl = url;
             retryCount = 0;
-            firstRetryTime = null; // Reset the time window
             clearRetryTimer();
             attemptConnect(url);
             break;

--- a/Web/src/pages/ImportFSBL/index.tsx
+++ b/Web/src/pages/ImportFSBL/index.tsx
@@ -4,15 +4,27 @@ import { useLingui } from '@lingui/react';
 import SvgIcon from '@/components/svg-icon';
 import systemApis from '@/services/api/system';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import WifiReloadMask from '@/components/wifi-reload-mask';
+import { toast } from 'sonner';
+import { retryFetch, sleep } from '@/utils';
+
+const ACCEPT_FILE_TYPE = {
+    'application/octet-stream': ['.bin'],
+};
+const MAX_SIZE = 1024 * 1024 * 10;
 
 export default function ImportFSBL() {
     const { i18n } = useLingui();
-    const { uploadOTAFileReq, updateOTAReq, restartDevice } = systemApis;
-    const [fsblFile, setfsblFile] = useState<File | null>(null)
+    const { uploadOTAFileReq, updateOTAReq, restartDevice, getDeviceInfoReq } = systemApis;
+    const [fsblFile, setFsblFile] = useState<File | null>(null);
+    const [uploadLoading, setUploadLoading] = useState(false);
+    const [isBurning, setIsBurning] = useState(false);
+    const [isRestarting, setIsRestarting] = useState(false);
 
     const uploadFSBL = async (file: File) => {
         try {
-            setfsblFile(file);
+            setUploadLoading(true);
             await uploadOTAFileReq(file, 'fsbl');
             await updateOTAReq({
                 filename: file.name,
@@ -20,68 +32,104 @@ export default function ImportFSBL() {
                 validate_crc32: true,
                 validate_signature: true,
                 allow_downgrade: true,
-                auto_upgrade: true
+                auto_upgrade: true,
             });
+            setFsblFile(file);
         } catch (error) {
             console.error('uploadFSBL', error);
             throw error;
+        } finally {
+            setUploadLoading(false);
         }
-    }
+    };
 
     const handleUpdate = async () => {
+        if (!fsblFile) {
+            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
+            return;
+        }
         try {
-            restartDevice({ delay_seconds: 1 });
+            setIsBurning(true);
+            setIsRestarting(true);
+            await restartDevice({ delay_seconds: 1 }, { skipErrorToast: true });
+            await sleep(8000);
+            const result = await retryFetch(
+                (signal) => getDeviceInfoReq({ skipErrorToast: true, signal }),
+                5000,
+                10,
+            );
+            if (result) {
+                toast.success(i18n._('sys.system_management.update_success'));
+            }
         } catch (error) {
             console.error('handleUpdate', error);
             throw error;
+        } finally {
+            setIsRestarting(false);
+            setIsBurning(false);
         }
-    }
+    };
 
-    const customUpload = ({ placeholder, fileName }: { placeholder: string, fileName: string }) => (
-        <div className="flex flex-col gap-2 flex-1 items-center justify-center w-full h-full rounded-md">
-            {
-                fileName ? (
-                    <div className="flex flex-col items-center gap-2">
-                        <div className="w-14 h-14 bg-gray-400 rounded-md flex items-center justify-center">
-                            <SvgIcon className="w-10 h-10" icon="file" />
-                        </div>
-                        <p className="text-sm items-center  text-wrap text-text-primary">{fileName}</p>
+    const renderUploadSlot = () => (
+        <div className="flex flex-col gap-3 flex-1 items-center justify-center w-full h-full px-4 py-4 text-center">
+            {fsblFile ? (
+                <div className="flex flex-col items-center gap-3 pointer-events-none">
+                    <div className="w-14 h-14 bg-primary/10 text-primary rounded-lg flex items-center justify-center">
+                        <SvgIcon className="w-8 h-8" icon="file" />
                     </div>
-                ) : (
-                    <div className="flex flex-col gap-2 flex-1 items-center justify-center w-full h-full">
-                        <SvgIcon className="w-10 h-10" icon="upload_single" />
-                        <p className="text-sm items-center  text-wrap text-text-secondary">{placeholder}</p>
-                    </div>
-                )
-            }
-        </div>
-    )
-    return (
-        <div className="w-full h-full flex justify-center pt-4">
-            <div className="md:max-w-xl mx-4 w-full flex flex-col gap-2">
-                <Upload
-                  className="h-50"
-                  type="customZone"
-                  slot={customUpload({ placeholder: i18n._('sys.system_management.fsbl_file'), fileName: fsblFile?.name || '' })}
-                  accept={{
-                        'application/octet-stream': ['.bin'],
-                    }}
-                  maxFiles={1}
-                  maxSize={1024 * 1024 * 10}
-                  multiple={false}
-                  onFileChange={uploadFSBL}
-                />
-
-                <div className="flex gap-2 justify-end">
-                    <Button
-                      variant="primary"
-                      className="w-1/2 md:w-auto"
-                      onClick={() => handleUpdate()}
-                    >
-                        {i18n._('sys.system_management.confirm_burn')}
-                    </Button>
+                    <p className="text-sm text-text-primary text-wrap break-all max-w-[85%]">{fsblFile.name}</p>
+                    <p className="text-xs text-text-secondary">{i18n._('common.reupload')}</p>
                 </div>
-            </div>
+            ) : (
+                <div className="flex flex-col gap-2 items-center justify-center pointer-events-none">
+                    <SvgIcon className="w-12 h-12 text-text-secondary" icon="upload_single" />
+                    <p className="text-sm text-text-secondary">{i18n._('sys.system_management.fsbl_file')}</p>
+                    <p className="text-xs text-text-secondary/70">.bin</p>
+                </div>
+            )}
+        </div>
+    );
+
+    return (
+        <div className="w-full h-full flex justify-center items-start pt-4">
+            {isBurning && (
+                <WifiReloadMask
+                  isLoading={isRestarting}
+                  loadingText={i18n._('sys.system_management.firmware_upgrade_desc')}
+                  maskText={i18n._('sys.system_management.firmware_upgrade_success')}
+                />
+            )}
+            <Card className="md:max-w-xl mx-4 w-full">
+                <CardContent className="flex flex-col gap-4">
+                    <div className="flex flex-col gap-1">
+                        <p className="text-sm text-text-primary font-bold">{i18n._('sys.system_management.header_import_firmware')}</p>
+                        <p className="text-xs text-text-secondary">*{i18n._('sys.system_management.fsbl_file')}</p>
+                    </div>
+
+                    <Upload
+                      className="h-64 w-full"
+                      type="customZone"
+                      slot={renderUploadSlot()}
+                      accept={ACCEPT_FILE_TYPE}
+                      maxFiles={1}
+                      maxSize={MAX_SIZE}
+                      multiple={false}
+                      loading={uploadLoading}
+                      onFileChange={uploadFSBL}
+                    />
+
+                    <div className="flex gap-2 justify-end">
+                        <Button
+                          variant="primary"
+                          className="w-1/2 md:w-auto"
+                          disabled={!fsblFile || uploadLoading || isBurning}
+                          onClick={() => handleUpdate()}
+                        >
+                            {i18n._('sys.system_management.confirm_burn')}
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
         </div>
     );
 }

--- a/Web/src/pages/ImportFSBL/index.tsx
+++ b/Web/src/pages/ImportFSBL/index.tsx
@@ -18,13 +18,25 @@ export default function ImportFSBL() {
     const { i18n } = useLingui();
     const { uploadOTAFileReq, updateOTAReq, restartDevice, getDeviceInfoReq } = systemApis;
     const [fsblFile, setFsblFile] = useState<File | null>(null);
-    const [uploadLoading, setUploadLoading] = useState(false);
     const [isBurning, setIsBurning] = useState(false);
     const [isRestarting, setIsRestarting] = useState(false);
 
+    // Selecting a file only stores it locally. The actual burn starts on "confirm burn".
     const uploadFSBL = async (file: File) => {
+        setFsblFile(file);
+    };
+
+    const handleUpdate = async () => {
+        if (!fsblFile) {
+            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
+            return;
+        }
+        const file = fsblFile;
         try {
-            setUploadLoading(true);
+            setIsBurning(true);
+            setIsRestarting(true);
+            // /ota/upload writes the firmware to flash (the actual burn); upgrade-local
+            // finalizes it, then restart activates it. All of this runs on "confirm burn".
             await uploadOTAFileReq(file, 'fsbl');
             await updateOTAReq({
                 filename: file.name,
@@ -34,23 +46,6 @@ export default function ImportFSBL() {
                 allow_downgrade: true,
                 auto_upgrade: true,
             });
-            setFsblFile(file);
-        } catch (error) {
-            console.error('uploadFSBL', error);
-            throw error;
-        } finally {
-            setUploadLoading(false);
-        }
-    };
-
-    const handleUpdate = async () => {
-        if (!fsblFile) {
-            toast.error(i18n._('sys.system_management.please_select_firmware_file'));
-            return;
-        }
-        try {
-            setIsBurning(true);
-            setIsRestarting(true);
             await restartDevice({ delay_seconds: 1 }, { skipErrorToast: true });
             await sleep(8000);
             const result = await retryFetch(
@@ -59,14 +54,13 @@ export default function ImportFSBL() {
                 10,
             );
             if (result) {
+                setIsBurning(false);
                 toast.success(i18n._('sys.system_management.update_success'));
             }
         } catch (error) {
             console.error('handleUpdate', error);
-            throw error;
         } finally {
             setIsRestarting(false);
-            setIsBurning(false);
         }
     };
 
@@ -96,7 +90,7 @@ export default function ImportFSBL() {
                 <WifiReloadMask
                   isLoading={isRestarting}
                   loadingText={i18n._('sys.system_management.firmware_upgrade_desc')}
-                  maskText={i18n._('sys.system_management.firmware_upgrade_success')}
+                  maskText={i18n._('sys.system_management.network_disconnected')}
                 />
             )}
             <Card className="md:max-w-xl mx-4 w-full">
@@ -114,7 +108,6 @@ export default function ImportFSBL() {
                       maxFiles={1}
                       maxSize={MAX_SIZE}
                       multiple={false}
-                      loading={uploadLoading}
                       onFileChange={uploadFSBL}
                     />
 
@@ -122,7 +115,7 @@ export default function ImportFSBL() {
                         <Button
                           variant="primary"
                           className="w-1/2 md:w-auto"
-                          disabled={!fsblFile || uploadLoading || isBurning}
+                          disabled={!fsblFile || isBurning}
                           onClick={() => handleUpdate()}
                         >
                             {i18n._('sys.system_management.confirm_burn')}

--- a/Web/src/pages/systemSettings/communication/wifi-network.tsx
+++ b/Web/src/pages/systemSettings/communication/wifi-network.tsx
@@ -15,7 +15,7 @@ import systemSettings from '@/services/api/systemSettings';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Input } from '@/components/ui/input';
 import WifiReloadMask from '@/components/wifi-reload-mask';
-import { sleep, retryFetch } from '@/utils';
+import { sleep } from '@/utils';
 import { useCommunicationData } from '@/store/communicationData';
 
 type WifiData = {
@@ -28,6 +28,13 @@ type WifiData = {
     is_known: boolean;
     last_connected_time: number;
 }
+
+// When refreshing/reconnecting, poll the STA interface instead of failing fast on a
+// transient 500. Only surface "network disconnected" after this timeout elapses.
+const POLL_TIMEOUT = 20000;
+const POLL_INTERVAL = 1000;
+const POLL_REQUEST_TIMEOUT = 2000;
+
 export default function WifiNetworkPage() {
     const { i18n } = useLingui();
     const isMobile = useIsMobile();
@@ -166,7 +173,7 @@ export default function WifiNetworkPage() {
                     interface: 'wl'
                 }).then(resolve).catch(reject);
             })
-            await reloadMask(setWifiFn, 3000, 3, i18n._('sys.system_management.connecting_network'));
+            await reloadMask(setWifiFn, i18n._('sys.system_management.connecting_network'));
         } catch (error) {
             console.error('handleConnectWifi', error);
         } finally {
@@ -196,7 +203,7 @@ export default function WifiNetworkPage() {
             await scanWifi();
             await sleep(3000);
         };
-        reloadMask(waitScanWifi, 3000, 3, i18n._('sys.system_management.scanning_network'));
+        reloadMask(waitScanWifi, i18n._('sys.system_management.scanning_network'));
     }
     const handleDeleteWifi = async (wifiData: WifiData) => {
         try {
@@ -207,27 +214,51 @@ export default function WifiNetworkPage() {
         }
     }
 
-    const reloadMask = async (fetchFn: () => Promise<any>, loadingTime: number, loadCount: number, _loadingText: string) => {
+    // Raw STA request used while reconnecting. It throws on failure so the poll loop
+    // below can retry, and suppresses error toasts so a reconnecting device does not
+    // spam "500" notifications on every attempt.
+    const pollNetworkSTA = async (timeoutMs: number) => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+            const res = await getNetworkSTAReq({ skipErrorToast: true, signal: controller.signal });
+            setCurrentWifiData(res.data);
+            setKnownWifiDataList(res.data.scan_results.known_networks);
+            setOtherWifiDataList(res.data.scan_results.unknown_networks);
+            return res;
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+
+    const reloadMask = async (fetchFn: () => Promise<any>, _loadingText: string) => {
         setLoadingText(_loadingText);
         setIsReloading(true);
         setShowWifiReloadMask(true);
-        fetchFn().then(async () => {
-            const result = await retryFetch(getNetworkSTA, loadingTime, loadCount);
-            if (result) {
-                setShowWifiReloadMask(false);
+        try {
+            await fetchFn();
+        } catch (error) {
+            console.error('reloadMask fetchFn', error);
+        }
+        // Poll the STA interface until it responds again or the timeout elapses.
+        // Only keep the "network disconnected" mask visible if polling truly times out.
+        let reconnected = false;
+        const start = Date.now();
+        /* eslint-disable no-await-in-loop -- sequential polling is intentional */
+        while (Date.now() - start < POLL_TIMEOUT) {
+            try {
+                await pollNetworkSTA(POLL_REQUEST_TIMEOUT);
+                reconnected = true;
+                break;
+            } catch {
+                await sleep(POLL_INTERVAL);
             }
-        }).catch(async (error) => {
-            if (error.status && error.status === 200) {
-                const result = await retryFetch(getNetworkSTA, loadingTime, loadCount);
-                if (result) {
-                    setShowWifiReloadMask(false);
-                }
-            }
-            throw error;
-        })
-            .finally(() => {
-                setIsReloading(false);
-            });
+        }
+        /* eslint-enable no-await-in-loop */
+        if (reconnected) {
+            setShowWifiReloadMask(false);
+        }
+        setIsReloading(false);
     }
     return (
         <div className="mt-2">

--- a/Web/src/services/api/systemSettings.ts
+++ b/Web/src/services/api/systemSettings.ts
@@ -78,7 +78,7 @@ const systemSettings = {
     prioritizeNetworkReq: (data: { interface: string }) => request.post('/api/v1/system/network/comm/prioritize', data),
 
     // wifi
-    getNetworkSTAReq: () => request.get('/api/v1/system/network/wifi/sta'),
+    getNetworkSTAReq: (config?: { skipErrorToast?: boolean; signal?: AbortSignal }) => request.get('/api/v1/system/network/wifi/sta', config),
     getAPConfigReq: () => request.get('/api/v1/system/network/wifi/ap'),
     scanWifi: () => request.post('/api/v1/system/network/wifi/scan'),
     setWifi: (data: SetWifiReq) => request.post('/api/v1/system/network/wifi', data),

--- a/Web/src/test/media.test.ts
+++ b/Web/src/test/media.test.ts
@@ -2,21 +2,15 @@ import { describe, expect, it, vi } from 'vitest';
 import MsMediaSource from '@/lib/MSE/media';
 
 interface MediaInternals {
-  sourceBuffer: {
-    buffered: TimeRanges;
-  };
-  isSafari: boolean;
+  sourceBuffer: { buffered: TimeRanges };
+  isIOSWebKit: boolean;
   isPlayback: boolean;
-  liveTargetLatency: number;
-  liveHardCatchUpLatency: number;
-  stallRecoveryDelayMs: number;
-  startupMinBufferedSeconds: number;
-  lastPlaybackTime: number;
-  lastPlaybackAdvanceMs: number;
-  lastPlayheadCorrectionMs: number;
-  handlePlaybackTimeUpdate(): void;
-  startPlaybackIfReady(): void;
-  syncLivePreview(forceRecovery?: boolean): void;
+  waitingForBuffer: boolean;
+  hasStartedPlayback: boolean;
+  lastLiveSyncMs: number;
+  stallStartedMs: number | null;
+  syncLivePreview(liveEdge: number, bufferTime: number): void;
+  recoverIfNeeded(): void;
 }
 
 function makeRanges(start: number, end: number): TimeRanges {
@@ -27,73 +21,59 @@ function makeRanges(start: number, end: number): TimeRanges {
   };
 }
 
-function setupSafariMedia(currentTime: number, rangeEnd: number) {
+function setupMedia(isIOS: boolean, currentTime: number, liveEdge: number) {
   const media = new MsMediaSource(() => {});
   const video = document.createElement('video');
   video.currentTime = currentTime;
+  const play = vi.spyOn(video, 'play').mockResolvedValue();
   media.setVideoElement(video);
 
   const internals = media as unknown as MediaInternals;
-  internals.isSafari = true;
+  internals.isIOSWebKit = isIOS;
   internals.isPlayback = false;
-  internals.liveTargetLatency = 0.6;
-  internals.liveHardCatchUpLatency = 1.5;
-  internals.stallRecoveryDelayMs = 3000;
-  internals.startupMinBufferedSeconds = 0.45;
-  internals.sourceBuffer = {
-    buffered: makeRanges(0, rangeEnd),
-  };
+  internals.waitingForBuffer = false;
+  internals.hasStartedPlayback = true;
+  internals.lastLiveSyncMs = 0;
+  internals.sourceBuffer = { buffered: makeRanges(0, liveEdge) };
 
-  return { internals, video };
+  return { internals, media, play, video };
 }
 
-describe('MsMediaSource Safari live playhead', () => {
-  it('waits for a safe Safari startup buffer before playing', async () => {
-    const { internals, video } = setupSafariMedia(0, 0.2);
-    const play = vi.spyOn(video, 'play').mockResolvedValue();
+describe('MsMediaSource live catch-up', () => {
+  it('uses a low-frequency seek instead of playbackRate on iOS', () => {
+    const { internals, play, video } = setupMedia(true, 8.8, 10);
 
-    internals.startPlaybackIfReady();
-    expect(play).not.toHaveBeenCalled();
+    internals.syncLivePreview(10, 1.2);
 
-    internals.sourceBuffer.buffered = makeRanges(0, 0.5);
-    internals.startPlaybackIfReady();
-    await Promise.resolve();
-
+    expect(video.currentTime).toBeCloseTo(9.6);
+    expect(video.playbackRate).toBe(1);
     expect(play).toHaveBeenCalledOnce();
-    play.mockRestore();
   });
 
-  it('restores a buffered high-water mark after WebKit moves backwards', () => {
-    const { internals, video } = setupSafariMedia(8.6, 10);
-    internals.lastPlaybackTime = 9;
-    internals.lastPlayheadCorrectionMs = 0;
+  it('does not repeatedly seek on iOS during the cooldown', () => {
+    const { internals, video } = setupMedia(true, 8.8, 10);
+    internals.lastLiveSyncMs = Date.now();
 
-    internals.handlePlaybackTimeUpdate();
+    internals.syncLivePreview(10, 1.2);
 
-    expect(video.currentTime).toBe(9);
+    expect(video.currentTime).toBe(8.8);
   });
 
-  it('does not seek merely because normal Safari playback is behind live', () => {
-    const { internals, video } = setupSafariMedia(6, 10);
-    internals.lastPlaybackTime = 6;
-    internals.lastPlaybackAdvanceMs = Date.now();
-    const play = vi.spyOn(video, 'play').mockResolvedValue();
+  it('keeps smooth playbackRate catch-up on desktop browsers', () => {
+    const { internals, video } = setupMedia(false, 9.3, 10);
 
-    internals.syncLivePreview(false);
+    internals.syncLivePreview(10, 0.7);
 
-    expect(video.currentTime).toBe(6);
-    play.mockRestore();
+    expect(video.currentTime).toBe(9.3);
+    expect(video.playbackRate).toBeGreaterThan(1);
   });
 
-  it('does not seek for a short Safari waiting event', () => {
-    const { internals, video } = setupSafariMedia(6, 10);
-    internals.lastPlaybackTime = 6;
-    internals.lastPlaybackAdvanceMs = Date.now() - 1500;
-    const play = vi.spyOn(video, 'play').mockResolvedValue();
+  it('does not enter rebuffering for a short iOS waiting event', () => {
+    const { internals, video } = setupMedia(true, 9.4, 10);
 
-    internals.syncLivePreview(true);
+    video.dispatchEvent(new Event('waiting'));
 
-    expect(video.currentTime).toBe(6);
-    play.mockRestore();
+    expect(internals.stallStartedMs).not.toBeNull();
+    expect(internals.waitingForBuffer).toBe(false);
   });
 });


### PR DESCRIPTION
## Changes
- **Live preview**: stabilize 25fps playback, fix dropped frames.
- **WiFi reconnect**: poll `/wifi/sta` instead of failing fast on a transient `500`; show "network disconnected" only after polling times out.
- **FSBL burn**: selecting a file no longer burns immediately — burn starts only on "Confirm burn"; poll the device until it comes back, show "network disconnected" only on timeout.