### PR TITLE
Stop truncating the last NAL of every RTMP frame

### DIFF
--- a/Custom/Hal/Network/rtmp_push_client/rtmp_publisher.c
+++ b/Custom/Hal/Network/rtmp_push_client/rtmp_publisher.c
@@ -55,30 +55,41 @@ static const uint8_t* find_nal_start(const uint8_t *data, uint32_t size, uint32_
             const uint8_t *next_start = nal_start;
             
             // Find next start code
-            while (next_start < end - 3) {
-                if (next_start[0] == 0 && next_start[1] == 0 && 
+            while (end - next_start >= 4) {
+                if (next_start[0] == 0 && next_start[1] == 0 &&
                     next_start[2] == 0 && next_start[3] == 1) {
                     break;
                 }
                 next_start++;
             }
-            
-            *nal_size = next_start - nal_start;
+
+            // None found: this NAL runs to the end of the buffer
+            if (end - next_start < 4) {
+                next_start = end;
+            }
+
+            *nal_size = (uint32_t)(next_start - nal_start);
             return nal_start;
         } else if (p[0] == 0 && p[1] == 0 && p[2] == 1) {
             // Found 3-byte start code
             const uint8_t *nal_start = p + 3;
             const uint8_t *next_start = nal_start;
             
-            // Find next start code
-            while (next_start < end - 2) {
-                if (next_start[0] == 0 && next_start[1] == 0 && 
-                    (next_start[2] == 1 || (next_start[2] == 0 && next_start[3] == 1))) {
+            // Find next start code; the length guard keeps next_start[3]
+            // inside the buffer
+            while (end - next_start >= 3) {
+                if (next_start[0] == 0 && next_start[1] == 0 &&
+                    (next_start[2] == 1 ||
+                     (end - next_start >= 4 && next_start[2] == 0 && next_start[3] == 1))) {
                     break;
                 }
                 next_start++;
             }
-            
+
+            if (end - next_start < 3) {
+                next_start = end;
+            }
+
             *nal_size = (uint32_t)(next_start - nal_start);
             return nal_start;
         }


### PR DESCRIPTION
## What

`find_nal_start()` reports the **final** NAL of every buffer as three bytes shorter than it is, so every frame pushed over RTMP loses the last three bytes of its coded slice.

The inner scan looks for the next start code with `while (next_start < end - 3)`. The last NAL has no next start code, so the scan runs to that bound and `*nal_size` comes out short by exactly the three bytes the bound left unexamined. That NAL is always the coded slice: `H264Init.c:541` sets `sliceSize = 0` and `enc.c:292` sets `sendAUD = 0`, so there is one slice per picture and nothing after it. Start codes are 4-byte (`enc.c:345`), and there is no trailing padding to absorb the loss. Both conversion passes share the helper, so the AVCC length prefix and the copied payload agree and the packet looks well-formed on the wire; the damage is invisible without decoding. The sibling RTSP walker is unaffected: `rtsp_rtp.c:222-224` takes the remainder.

The scan now takes the remainder when no further start code exists. The 3-byte-start-code branch also guards `next_start[3]`, which read one byte past the buffer once only three bytes remained. A post-loop size clamp would have corrected the length but not that read.

Every pushed frame is non-conforming as a result. libavcodec conceals most of it, but roughly 4% of frames produce a visible macroblock error, and because the loss is at the tail of the slice the damage lands in the last macroblock row.

## Testing

Two NE301s streaming 720p30 over RTMP, decoded with `ffmpeg -threads 1`.

A conforming RBSP ends in `rbsp_stop_one_bit`, so its final byte can never be `0x00`; truncation instead exposes an arbitrary interior byte, which is `0x00` about 1 time in 256. That makes the defect measurable without trusting any decoder.

Before, 10-minute captures from both cameras:

| | cam A | cam B |
|---|---|---|
| access units | 17,740 | 17,707 |
| AU-final byte `0x00` | 81 (0.457%) | 63 (0.356%) |
| vs 1/256 = 0.391% | z = +1.41 | z = -0.74 |
| macroblock errors in the last row | 100.0% | 99.9% |
| bytestream underruns, single-digit | 100% | 100% |

After, with one camera patched and the other deliberately held on the unpatched build as a concurrent control, same 10-minute window:

| | control | patched |
|---|---|---|
| access units | 16,524 | 17,197 |
| AU-final byte `0x00` | 65 (0.393%) | **0** |
| decoder error lines | 4,027 | **0** |

Zero decoder errors over 17,197 access units, against 4,027 on the control in the same window. Replaying both versions of the walker over one 600-access-unit reference stream gives 3.00 payload bytes lost per access unit and 785 decoder error lines before, 0 and 0 after.

Both cameras have since run on patched builds, streaming ~29 fps at 7,400-7,600 bytes/frame with a further capture confirming zero decoder errors on each. The fix adds three bytes per frame, a 0.04% bitrate change.
