### PR TITLE
Do not publish a camera buffer the DCMIPP is still writing into

### DIFF
--- a/Custom/Hal/camera.c
+++ b/Custom/Hal/camera.c
@@ -1346,6 +1346,12 @@ static int camera_ioctl(void *priv, unsigned int cmd, unsigned char* ubuf, unsig
                 ret = AICAM_ERROR_INVALID_PARAM;
                 break;
             }
+            /* One buffer cannot work: the frame event needs somewhere to write
+               while a consumer holds the published frame. */
+            if(((pipe_params_t *)ubuf)->buffer_nb < 2){
+                ret = AICAM_ERROR_INVALID_PARAM;
+                break;
+            }
             memcpy(&camera->pipe1_param, ubuf, sizeof(pipe_params_t));
             ret = DCMIPP_Pipe1Init(camera);
             break;
@@ -1356,6 +1362,12 @@ static int camera_ioctl(void *priv, unsigned int cmd, unsigned char* ubuf, unsig
                 break;
             }
             if(ubuf == NULL || arg != sizeof(pipe_params_t)){
+                ret = AICAM_ERROR_INVALID_PARAM;
+                break;
+            }
+            /* One buffer cannot work: the frame event needs somewhere to write
+               while a consumer holds the published frame. */
+            if(((pipe_params_t *)ubuf)->buffer_nb < 2){
                 ret = AICAM_ERROR_INVALID_PARAM;
                 break;
             }

--- a/Custom/Hal/camera.c
+++ b/Custom/Hal/camera.c
@@ -830,6 +830,15 @@ static void main_pipe_frame_event()
             buffer_release_isr(buffer, &g_camera.pipe1_dq);
         }
     }else if(buffer1 != NULL && buffer1->data != NULL){
+        /*
+         * buffer1 was marked BUFFER_READY above but the DCMIPP is about to
+         * DMA into it; demote it so it cannot be handed out mid-write. Only
+         * when buffer == NULL: otherwise buffer_acquire already promoted a
+         * different buffer, and a second PROCESSING buffer would break
+         * find_processing_buffer.
+         */
+        if (buffer == NULL)
+            buffer1->state = BUFFER_PROCESSING;
         ret = HAL_DCMIPP_PIPE_SetMemoryAddress(CMW_CAMERA_GetDCMIPPHandle(), DCMIPP_PIPE1,
                                                 DCMIPP_MEMORY_ADDRESS_0, (uint32_t) buffer1->data);
         if(ret == HAL_OK){
@@ -874,6 +883,9 @@ static void ancillary_pipe_frame_event()
             buffer_release_isr(buffer, &g_camera.pipe2_dq);
         }
     }else if(buffer1 != NULL && buffer1->data != NULL){
+        /* Same demote as main_pipe_frame_event above. */
+        if (buffer == NULL)
+            buffer1->state = BUFFER_PROCESSING;
         ret = HAL_DCMIPP_PIPE_SetMemoryAddress(CMW_CAMERA_GetDCMIPPHandle(), DCMIPP_PIPE2,
                                                 DCMIPP_MEMORY_ADDRESS_0, (uint32_t) buffer1->data);
         if(ret == HAL_OK){

--- a/Custom/Hal/camera.c
+++ b/Custom/Hal/camera.c
@@ -1084,14 +1084,23 @@ static int pipe_stop_common(camera_t *camera, uint32_t pipe_id, pipe_buffer_t **
             return AICAM_OK;
         }else{
             /*
-             * The pipe is still running but the frame interrupt was disabled
-             * above; re-arm it or no frame event ever fires again and
-             * camera_start short-circuits on the unchanged pipe_state.
+             * The stop failed and PIPEN says which half. If the pipe is still
+             * enabled, DCMIPP_Stop timed out with the capture request already
+             * cleared: DMA may still be active so the buffers must stay, and
+             * re-enabling the interrupt alone would not bring frames back --
+             * re-assert the capture request so the pipe genuinely keeps
+             * running for the caller's retry. If the pipe is disabled, the
+             * capture drained but the CSI virtual channel failed to stop; the
+             * HAL pipe state cannot be rebuilt from here, so just report it.
              */
             if (hdcmipp != NULL) {
-                if (pipe_id == DCMIPP_PIPE1) {
+                if (pipe_id == DCMIPP_PIPE1 &&
+                    (hdcmipp->Instance->P1FSCR & DCMIPP_P1FSCR_PIPEN) != 0U) {
+                    SET_BIT(hdcmipp->Instance->P1FCTCR, DCMIPP_P1FCTCR_CPTREQ);
                     __HAL_DCMIPP_ENABLE_IT(hdcmipp, DCMIPP_IT_PIPE1_FRAME | DCMIPP_IT_PIPE1_VSYNC);
-                } else if (pipe_id == DCMIPP_PIPE2) {
+                } else if (pipe_id == DCMIPP_PIPE2 &&
+                           (hdcmipp->Instance->P2FSCR & DCMIPP_P2FSCR_PIPEN) != 0U) {
+                    SET_BIT(hdcmipp->Instance->P2FCTCR, DCMIPP_P2FCTCR_CPTREQ);
                     __HAL_DCMIPP_ENABLE_IT(hdcmipp, DCMIPP_IT_PIPE2_FRAME | DCMIPP_IT_PIPE2_VSYNC);
                 }
             }

--- a/Custom/Hal/camera.c
+++ b/Custom/Hal/camera.c
@@ -1083,6 +1083,18 @@ static int pipe_stop_common(camera_t *camera, uint32_t pipe_id, pipe_buffer_t **
             *pipe_buffer = NULL;
             return AICAM_OK;
         }else{
+            /*
+             * The pipe is still running but the frame interrupt was disabled
+             * above; re-arm it or no frame event ever fires again and
+             * camera_start short-circuits on the unchanged pipe_state.
+             */
+            if (hdcmipp != NULL) {
+                if (pipe_id == DCMIPP_PIPE1) {
+                    __HAL_DCMIPP_ENABLE_IT(hdcmipp, DCMIPP_IT_PIPE1_FRAME | DCMIPP_IT_PIPE1_VSYNC);
+                } else if (pipe_id == DCMIPP_PIPE2) {
+                    __HAL_DCMIPP_ENABLE_IT(hdcmipp, DCMIPP_IT_PIPE2_FRAME | DCMIPP_IT_PIPE2_VSYNC);
+                }
+            }
             LOG_DRV_ERROR("pipe%lu stop failed: %d\r\n", pipe_id, ret);
             return AICAM_ERROR;
         }


### PR DESCRIPTION
## What

The camera ISR can hand a consumer a frame that the capture hardware is still writing into. In
the frame event, when `buffer_acquire` returns NULL, the code re-points the DCMIPP at the buffer
it marked ready a few lines earlier (`camera.c:814`, `:832-840`) without changing that buffer's
state. The consumer selector (`camera.c:510`) picks any buffer with state `>= BUFFER_READY`,
preferring the newest frame id, which is exactly this one. The result is the encoder DMA-reading
a raster the DCMIPP is concurrently DMA-writing: a torn source frame.

The reason we fixed it, even without a measured rate: each occurrence silently corrupts one
delivered frame. Recorded video or a snapshot shows content from two different instants with a
seam between them, and an inference input is a picture that never existed in front of the sensor.
The frame is syntactically valid, so nothing downstream reports anything; to a user it is an
intermittent visual glitch that cannot be reproduced or attributed. That failure mode is the kind
that generates unresolvable support reports, which is why we think it is worth closing even
though the trigger is a race.

`ancillary_pipe_frame_event()` is a clone of the main pipe handler and has the same defect. Pipe2
is started by default and feeds inference and snapshots, so the fix lands in both handlers. We
kept to the file's existing structure rather than introducing a shared helper for the two clones.

On the evidence: the branch is provably reachable. It needs `mtx_isr != 0`, and there are in-tree
callers that satisfy that, for example `device_service.c:1573` takes a pipe1 buffer and then
blocks on pipe2 at `:1597` while still holding it, inside one ioctl. How often it fires in
practice depends on consumer hold times, and we have not measured a rate.

Three commits, because the one-line demote is not safe alone:

1. Demote the buffer to `BUFFER_PROCESSING` before programming the DCMIPP address, in both
   handlers. This is the same transition `buffer_acquire` performs from the same ISR (`:468`).
   The `buffer == NULL` guard matters: the branch is also reachable with a non-NULL buffer whose
   data pointer is NULL, where `buffer_acquire` has already promoted a different buffer, and
   demoting unconditionally would leave two processing buffers with `find_processing_buffer`
   taking the first by index.

2. Re-arm the frame interrupt when `HAL_DCMIPP_CSI_PIPE_Stop` fails (`camera.c:1073-1075`). That
   error path returns with the interrupt disabled and the pipe state unchanged, and
   `camera_start` then short-circuits without re-arming. Today that wedge serves a frozen frame
   forever; with the demote alone it would serve nothing forever, so the demote needs this repair
   to avoid making an existing failure mode worse.

3. Reject `buffer_nb < 2` in the pipe param setter. With a single buffer the demote would leave
   the pool permanently unselectable. No in-tree caller passes 1, but nothing enforced it.

Safety of the demote: the consumer cannot be holding the buffer when it runs, because
`buffer_set_ready_isr` clears the owner fields one statement earlier (`camera.c:486-490`) and the
whole sequence runs inside the DCMIPP ISR. The build is -O0, so there is no reordering hazard on
the ISR write.

The behaviour change is that a would-be torn frame becomes a dropped one. At `buffer_nb == 2` the
post-demote pool has nothing selectable, so a get returns `AICAM_ERROR_NOT_FOUND` and recovery
takes one frame period. The call sites tolerate that. This is unrelated to the decode errors
fixed in #40: a torn raster is still syntactically valid H.264, so decoder error counts should
not move.

## Testing

The change has run continuously on our hardware since it was built, with frame rate, drop rate
and reconnect behaviour unchanged, including across a full power-cycle recovery. That shows the
change is not harmful; it does not measure how often tearing occurred before it, and we are not
claiming a rate. The case for the change is the reachability argument above. If you want the rate
settled, a counter at the two demote sites would answer it, and snapshots taken during recording
(`device_service.c:1573`/`:1597`) force the branch deterministically.

While working on this we noticed two pre-existing oddities we did not touch: `buffer_reset:437`
writes `owner_list[i]` where `[j]` looks intended, and the second-owner path at `camera.c:531`
bumps `owner_count` without writing `owner_list`. Flagging rather than fixing, since we have not
investigated either.
