### PR TITLE
Escape the encoder's cold-start all-INTRA latch

### DIFF
--- a/Custom/Hal/enc.c
+++ b/Custom/Hal/enc.c
@@ -423,6 +423,14 @@ static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
     if (ret != H264ENC_OK)
         return ret;
 
+    /* Snapshot the configured bounds on the first escalation so recovery
+       restores them exactly (VBR runs with qpMin 10, not the header QP). */
+    if (enc->qp_floor_step == 0) {
+        enc->qp_orig_min = rate.qpMin;
+        enc->qp_orig_max = rate.qpMax;
+        enc->qp_orig_hdr = rate.qpHdr;
+    }
+
     /* qpHdr and qpMax must stay >= qpMin or the setter rejects the call;
        constant-QP mode pins qpMax to the configured QP. */
     rate.qpMin = qp_floor;
@@ -430,6 +438,23 @@ static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
         rate.qpHdr = qp_floor;
     if (rate.qpMax < qp_floor)
         rate.qpMax = qp_floor;
+
+    return H264EncSetRateCtrl(p_ctx->hdl, &rate);
+}
+
+static int ENC_H264_RestoreQp(enc_t *enc)
+{
+    struct VENC_Context *p_ctx = &VENC_Instance;
+    H264EncRateCtrl rate;
+    int ret;
+
+    ret = H264EncGetRateCtrl(p_ctx->hdl, &rate);
+    if (ret != H264ENC_OK)
+        return ret;
+
+    rate.qpMin = enc->qp_orig_min;
+    rate.qpMax = enc->qp_orig_max;
+    rate.qpHdr = enc->qp_orig_hdr;
 
     return H264EncSetRateCtrl(p_ctx->hdl, &rate);
 }
@@ -550,7 +575,7 @@ static void encProcess(void *argument)
         if (encode_ret == 0) {
             enc->startup_failures = 0;
             if (!enc->first_frame_done && enc->qp_floor_step) {
-                if (ENC_H264_SetQpFloor(enc, enc->params.rate_ctrl_dq) == H264ENC_OK)
+                if (ENC_H264_RestoreQp(enc) == H264ENC_OK)
                     LOG_DRV_WARN("encoder cold start cleared at QP floor %d, quality restored\r\n",
                                  enc->params.rate_ctrl_dq + enc->qp_floor_step * ENC_STARTUP_QP_STEP);
                 enc->qp_floor_step = 0;

--- a/Custom/Hal/enc.c
+++ b/Custom/Hal/enc.c
@@ -423,10 +423,13 @@ static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
     if (ret != H264ENC_OK)
         return ret;
 
-    /* qpHdr must stay inside [qpMin, qpMax] or the setter rejects the call */
+    /* qpHdr and qpMax must stay >= qpMin or the setter rejects the call;
+       constant-QP mode pins qpMax to the configured QP. */
     rate.qpMin = qp_floor;
     if (rate.qpHdr < qp_floor)
         rate.qpHdr = qp_floor;
+    if (rate.qpMax < qp_floor)
+        rate.qpMax = qp_floor;
 
     return H264EncSetRateCtrl(p_ctx->hdl, &rate);
 }

--- a/Custom/Hal/enc.c
+++ b/Custom/Hal/enc.c
@@ -402,6 +402,35 @@ static int ENC_H264_Init(enc_t *enc)
     return ret;
 }
 
+/*
+ * Cold-start escape. While encStatus holds H264ENCSTAT_START_STREAM the
+ * library forces every frame to INTRA and only a completed INTRA clears it
+ * (H264EncApi.c:1921-1923, :2647); a re-init lands back in the same state.
+ * So escape asks for a cheaper frame rather than retrying: the QP floor is
+ * a hard clamp in the rate controller (H264RateControl.c:934).
+ */
+#define ENC_STARTUP_FAILURE_THRESHOLD 30  /* ~1 s at 30 fps */
+#define ENC_STARTUP_QP_STEP           8
+#define ENC_QP_MAX                    51
+
+static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
+{
+    struct VENC_Context *p_ctx = &VENC_Instance;
+    H264EncRateCtrl rate;
+    int ret;
+
+    ret = H264EncGetRateCtrl(p_ctx->hdl, &rate);
+    if (ret != H264ENC_OK)
+        return ret;
+
+    /* qpHdr must stay inside [qpMin, qpMax] or the setter rejects the call */
+    rate.qpMin = qp_floor;
+    if (rate.qpHdr < qp_floor)
+        rate.qpHdr = qp_floor;
+
+    return H264EncSetRateCtrl(p_ctx->hdl, &rate);
+}
+
 static void ENC_DeInit()
 {
     struct VENC_Context *p_ctx = &VENC_Instance;
@@ -512,6 +541,33 @@ static void encProcess(void *argument)
         
 #if USE_H264_VENC
         encode_ret = VENC_H264_Encode(enc);
+
+        /* Cold-start escape: step the QP floor up while no frame has
+           succeeded since init, restore normal quality on first success. */
+        if (encode_ret == 0) {
+            enc->startup_failures = 0;
+            if (!enc->first_frame_done && enc->qp_floor_step) {
+                if (ENC_H264_SetQpFloor(enc, enc->params.rate_ctrl_dq) == H264ENC_OK)
+                    LOG_DRV_WARN("encoder cold start cleared at QP floor %d, quality restored\r\n",
+                                 enc->params.rate_ctrl_dq + enc->qp_floor_step * ENC_STARTUP_QP_STEP);
+                enc->qp_floor_step = 0;
+            }
+            enc->first_frame_done = 1;
+        } else if (!enc->first_frame_done &&
+                   ++enc->startup_failures >= ENC_STARTUP_FAILURE_THRESHOLD) {
+            int qp_floor = enc->params.rate_ctrl_dq +
+                           (enc->qp_floor_step + 1) * ENC_STARTUP_QP_STEP;
+
+            enc->startup_failures = 0;
+            if (qp_floor <= ENC_QP_MAX) {
+                enc->qp_floor_step++;
+                if (ENC_H264_SetQpFloor(enc, qp_floor) == H264ENC_OK)
+                    LOG_DRV_WARN("encoder produced no frame since init; QP floor raised to %d\r\n",
+                                 qp_floor);
+                else
+                    LOG_DRV_ERROR("encoder cold start: QP floor %d rejected\r\n", qp_floor);
+            }
+        }
 #else
         encode_ret = encode_jpeg_frame(local_in, 
                                        enc->out_frame.frame_buffer + enc->out_frame.header_size,
@@ -563,6 +619,9 @@ static int enc_start(void *priv)
     }
     enc->state = ENC_IDLE;
     enc->is_intra_force = 1;
+    enc->first_frame_done = 0;
+    enc->startup_failures = 0;
+    enc->qp_floor_step = 0;
     osMutexRelease(enc->state_mtx);
 
     /* hardware initialization */

--- a/Custom/Hal/enc.h
+++ b/Custom/Hal/enc.h
@@ -78,6 +78,9 @@ typedef struct {
     uint8_t *in_buffer;
     enc_out_frame_t out_frame;
     int is_intra_force;
+    int first_frame_done;    /* set once any encode has succeeded since ENC_H264_Init */
+    int startup_failures;    /* consecutive failures before that first success */
+    int qp_floor_step;       /* cold-start escape step; 0 = normal quality */
 } enc_t;
 
 int enc_register(void);

--- a/Custom/Hal/enc.h
+++ b/Custom/Hal/enc.h
@@ -81,6 +81,9 @@ typedef struct {
     int first_frame_done;    /* set once any encode has succeeded since ENC_H264_Init */
     int startup_failures;    /* consecutive failures before that first success */
     int qp_floor_step;       /* cold-start escape step; 0 = normal quality */
+    int qp_orig_min;         /* rate-control bounds snapshotted at the first */
+    int qp_orig_max;         /*   escalation, restored on the first success */
+    int qp_orig_hdr;
 } enc_t;
 
 int enc_register(void);


### PR DESCRIPTION
## What

A camera can boot into a state where the encoder never produces a frame again, and neither a
reboot nor a power cycle clears it. We hit this in the field: a camera reported an active,
correctly configured stream while producing no frames at all, failing every encode at roughly 12
per second, and rebooting it landed back in the same state. We lost footage while everything the
camera reported said we were not.

The mechanism is in the encoder middleware. `H264EncStrmStart` leaves `encStatus` at
`H264ENCSTAT_START_STREAM` (`H264EncApi.c:1636`). While it holds that value,
`H264EncStrmEncode` overrides the requested coding type to INTRA (`:1921-1923`), and the only
transition out is on the success path (`:2647`); the timeout return at `:2495` leaves it
untouched. So if the first frame after an encoder init fails, every later frame is forced to a
full INTRA, and the only way out is an INTRA that completes. Re-initialising lands back in the
same state, which is why a reboot does not help.

To be upfront: this change is an escape hatch on the HAL side, not a fix of that defect, which we
cannot reach from our code. The last section says what we would rather have.

The change: once 30 consecutive failures have occurred with no frame yet successful since init,
the HAL raises the rate controller's QP floor by 8 via `H264EncSetRateCtrl`, asking the hardware
for a cheaper frame, and restores normal quality on the first success. It cannot trigger in
steady state, since it is gated on no frame having succeeded since init, and it stops stepping at
QP 51 rather than looping.

Why this works when retrying does not:

- The QP floor is a hard clamp in the rate controller (`H264RateControl.c:934`), so it reduces
  the work requested from the hardware regardless of what the rate model computes.
- The setter is callable while latched; its only status guard needs `hrd == ENCHW_YES`, and
  `enc.c:198` sets `hrd = 0`.
- The bitrate is unchanged, so `H264InitRc` runs with `newStream == false` and the rate control
  models are not reset.
- It changes a parameter, which is the one thing a reboot or re-init does not do.

## Testing

The latched state was reproduced live and the change escaped it. A camera entered the state on
boot after an OTA, and a full reboot re-entered it, confirming the reboot-proof behaviour.
Flashing a build with this change recovered it:

```
encoder produced no frame since init; QP floor raised to 33
encoder cold start cleared at QP floor 33, quality restored
```

Exactly 30 failures, one ladder step, escape on the next frame, normal quality restored the same
second. Streaming resumed at normal frame rate. Both cameras have run the change since with no
steady-state effect, as expected from the gating.

One observation offered without claiming a mechanism: the latch entries we have seen all happened
within minutes of 05:00 local time, and none of a dozen evening boots latched. Pre-dawn is where
the sensor sits at maximum gain and the image is noise-dominated, which would make the first IDR
the most expensive frame to encode. Two independent incidents is not enough to establish that,
but it is testable if useful to you.

## What we would rather have

The underlying defect is that `H264EncStrmEncode` can hold `encStatus` at `START_STREAM`
indefinitely when the frame it forced to INTRA keeps failing, with no transition out except a
success. A timeout return at `:2495` that backs the state out, or lets the caller's requested
coding type through, would remove the latch entirely, and this HAL change could then be dropped.
We are offering the escape because it is what we could do from outside the middleware, and it has
kept our cameras in service. If you would rather fix `H264EncApi.c` instead, we would happily
close this in favour of that.
