### PR TITLE
fix: hold the QP floor once the escape raises it

### DIFF
--- a/Custom/Hal/enc.c
+++ b/Custom/Hal/enc.c
@@ -51,6 +51,7 @@ static struct VENC_Context {
     H264EncInst hdl;
     JpegEncInst jdl;
     int is_sps_pps_done;
+    int last_enc_ret;
     uint64_t pic_cnt;
     int gop_len;
 } VENC_Instance;
@@ -292,8 +293,14 @@ static int VENC_H264_EncodeFrame(struct VENC_Context *p_ctx, uint8_t *p_in, uint
     enc_in.sendAUD = 0;
 
     ret = H264EncStrmEncode(p_ctx->hdl, &enc_in, p_enc_out, NULL, NULL, NULL);
-    if (ret != H264ENC_FRAME_READY)
+    if (ret != H264ENC_FRAME_READY) {
+        /* The caller collapses every failure to -1, which makes an output
+           buffer overflow indistinguishable from a hardware timeout in the
+           log. Keep the real code for the escalation line, which fires at
+           most three times per session. */
+        p_ctx->last_enc_ret = ret;
         return -1;
+    }
 
     p_ctx->pic_cnt++;
     *p_out_len = p_enc_out->streamSize;
@@ -403,17 +410,23 @@ static int ENC_H264_Init(enc_t *enc)
 }
 
 /*
- * Cold-start escape. While encStatus holds H264ENCSTAT_START_STREAM the
+ * QP-floor escape. While encStatus holds H264ENCSTAT_START_STREAM the
  * library forces every frame to INTRA and only a completed INTRA clears it
  * (H264EncApi.c:1921-1923, :2647); a re-init lands back in the same state.
  * So escape asks for a cheaper frame rather than retrying: the QP floor is
  * a hard clamp in the rate controller (H264RateControl.c:934).
+ *
+ * The floor only ever rises. Lowering it again on the first success put the
+ * encoder straight back into the configuration that had just failed, and
+ * cost five hours of capture on 2026-09-03. enc_start drops the floor and
+ * re-inits the codec at the configured quality, so a session that needed
+ * the escape keeps the floor that worked.
  */
-#define ENC_STARTUP_FAILURE_THRESHOLD 30  /* ~1 s at 30 fps */
+#define ENC_STARTUP_FAILURE_THRESHOLD 30  /* consecutive failures, ~1 s at 30 fps */
 #define ENC_STARTUP_QP_STEP           8
 #define ENC_QP_MAX                    51
 
-static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
+static int ENC_H264_SetQpFloor(int qp_floor)
 {
     struct VENC_Context *p_ctx = &VENC_Instance;
     H264EncRateCtrl rate;
@@ -422,14 +435,6 @@ static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
     ret = H264EncGetRateCtrl(p_ctx->hdl, &rate);
     if (ret != H264ENC_OK)
         return ret;
-
-    /* Snapshot the configured bounds on the first escalation so recovery
-       restores them exactly (VBR runs with qpMin 10, not the header QP). */
-    if (enc->qp_floor_step == 0) {
-        enc->qp_orig_min = rate.qpMin;
-        enc->qp_orig_max = rate.qpMax;
-        enc->qp_orig_hdr = rate.qpHdr;
-    }
 
     /* qpHdr and qpMax must stay >= qpMin or the setter rejects the call;
        constant-QP mode pins qpMax to the configured QP. */
@@ -438,23 +443,6 @@ static int ENC_H264_SetQpFloor(enc_t *enc, int qp_floor)
         rate.qpHdr = qp_floor;
     if (rate.qpMax < qp_floor)
         rate.qpMax = qp_floor;
-
-    return H264EncSetRateCtrl(p_ctx->hdl, &rate);
-}
-
-static int ENC_H264_RestoreQp(enc_t *enc)
-{
-    struct VENC_Context *p_ctx = &VENC_Instance;
-    H264EncRateCtrl rate;
-    int ret;
-
-    ret = H264EncGetRateCtrl(p_ctx->hdl, &rate);
-    if (ret != H264ENC_OK)
-        return ret;
-
-    rate.qpMin = enc->qp_orig_min;
-    rate.qpMax = enc->qp_orig_max;
-    rate.qpHdr = enc->qp_orig_hdr;
 
     return H264EncSetRateCtrl(p_ctx->hdl, &rate);
 }
@@ -570,30 +558,30 @@ static void encProcess(void *argument)
 #if USE_H264_VENC
         encode_ret = VENC_H264_Encode(enc);
 
-        /* Cold-start escape: step the QP floor up while no frame has
-           succeeded since init, restore normal quality on first success. */
+        /* QP-floor escape: step the floor up after a run of consecutive
+           failures and hold it for the rest of the session. */
         if (encode_ret == 0) {
             enc->startup_failures = 0;
-            if (!enc->first_frame_done && enc->qp_floor_step) {
-                if (ENC_H264_RestoreQp(enc) == H264ENC_OK)
-                    LOG_DRV_WARN("encoder cold start cleared at QP floor %d, quality restored\r\n",
-                                 enc->params.rate_ctrl_dq + enc->qp_floor_step * ENC_STARTUP_QP_STEP);
-                enc->qp_floor_step = 0;
-            }
-            enc->first_frame_done = 1;
-        } else if (!enc->first_frame_done &&
-                   ++enc->startup_failures >= ENC_STARTUP_FAILURE_THRESHOLD) {
-            int qp_floor = enc->params.rate_ctrl_dq +
-                           (enc->qp_floor_step + 1) * ENC_STARTUP_QP_STEP;
+        } else if (++enc->startup_failures >= ENC_STARTUP_FAILURE_THRESHOLD) {
+            int qp_floor = (enc->qp_floor ? enc->qp_floor
+                                          : enc->params.rate_ctrl_dq) +
+                           ENC_STARTUP_QP_STEP;
 
             enc->startup_failures = 0;
-            if (qp_floor <= ENC_QP_MAX) {
-                enc->qp_floor_step++;
-                if (ENC_H264_SetQpFloor(enc, qp_floor) == H264ENC_OK)
-                    LOG_DRV_WARN("encoder produced no frame since init; QP floor raised to %d\r\n",
-                                 qp_floor);
-                else
-                    LOG_DRV_ERROR("encoder cold start: QP floor %d rejected\r\n", qp_floor);
+            if (qp_floor > ENC_QP_MAX)
+                qp_floor = ENC_QP_MAX;
+            /* Once the top of the ladder is in force there is nothing left to
+               try, so say so once rather than re-evaluating in silence. */
+            if (qp_floor > enc->qp_floor) {
+                if (ENC_H264_SetQpFloor(qp_floor) == H264ENC_OK) {
+                    enc->qp_floor = qp_floor;
+                    LOG_DRV_WARN("encoder failed %d consecutive frames (enc ret %d); QP floor raised to %d%s\r\n",
+                                 ENC_STARTUP_FAILURE_THRESHOLD,
+                                 VENC_Instance.last_enc_ret, qp_floor,
+                                 (qp_floor == ENC_QP_MAX) ? " (ladder exhausted)" : "");
+                } else {
+                    LOG_DRV_ERROR("encoder escape: QP floor %d rejected\r\n", qp_floor);
+                }
             }
         }
 #else
@@ -647,9 +635,8 @@ static int enc_start(void *priv)
     }
     enc->state = ENC_IDLE;
     enc->is_intra_force = 1;
-    enc->first_frame_done = 0;
     enc->startup_failures = 0;
-    enc->qp_floor_step = 0;
+    enc->qp_floor = 0;
     osMutexRelease(enc->state_mtx);
 
     /* hardware initialization */

--- a/Custom/Hal/enc.c
+++ b/Custom/Hal/enc.c
@@ -559,10 +559,20 @@ static void encProcess(void *argument)
         encode_ret = VENC_H264_Encode(enc);
 
         /* QP-floor escape: step the floor up after a run of consecutive
-           failures and hold it for the rest of the session. */
+           output-buffer overflows and hold it for the rest of the session.
+           Gated on H264ENC_OUTPUT_BUFFER_OVERFLOW because raising the floor
+           only makes frames smaller: a bus error, data error, timeout or reset
+           is not a size problem and the ladder cannot clear it. On this SoC the
+           common background failure is H264ENC_HW_TIMEOUT, so counting every
+           return code would let a transient fault leave a recovered stream
+           pinned at a raised floor for the rest of the session. Other failure
+           codes neither advance nor reset the run; only a successful encode
+           does, so an overflow run is still caught if an unrelated error lands
+           in the middle of it. */
         if (encode_ret == 0) {
             enc->startup_failures = 0;
-        } else if (++enc->startup_failures >= ENC_STARTUP_FAILURE_THRESHOLD) {
+        } else if (VENC_Instance.last_enc_ret == H264ENC_OUTPUT_BUFFER_OVERFLOW &&
+                   ++enc->startup_failures >= ENC_STARTUP_FAILURE_THRESHOLD) {
             int qp_floor = (enc->qp_floor ? enc->qp_floor
                                           : enc->params.rate_ctrl_dq) +
                            ENC_STARTUP_QP_STEP;

--- a/Custom/Hal/enc.h
+++ b/Custom/Hal/enc.h
@@ -78,7 +78,7 @@ typedef struct {
     uint8_t *in_buffer;
     enc_out_frame_t out_frame;
     int is_intra_force;
-    int startup_failures;    /* consecutive failed encodes since the last success */
+    int startup_failures;    /* consecutive output-buffer overflows since the last success */
     int qp_floor;            /* QP floor in force; 0 = configured quality */
 } enc_t;
 

--- a/Custom/Hal/enc.h
+++ b/Custom/Hal/enc.h
@@ -78,12 +78,8 @@ typedef struct {
     uint8_t *in_buffer;
     enc_out_frame_t out_frame;
     int is_intra_force;
-    int first_frame_done;    /* set once any encode has succeeded since ENC_H264_Init */
-    int startup_failures;    /* consecutive failures before that first success */
-    int qp_floor_step;       /* cold-start escape step; 0 = normal quality */
-    int qp_orig_min;         /* rate-control bounds snapshotted at the first */
-    int qp_orig_max;         /*   escalation, restored on the first success */
-    int qp_orig_hdr;
+    int startup_failures;    /* consecutive failed encodes since the last success */
+    int qp_floor;            /* QP floor in force; 0 = configured quality */
 } enc_t;
 
 int enc_register(void);


### PR DESCRIPTION

This corrects two defects in the QP-floor escape we contributed in #46. Both are ours.

**1. The saved rate-control bounds are never written, so the restore sets QP 0.**

`ENC_H264_SetQpFloor` snapshots the current bounds under `if (enc->qp_floor_step == 0)`, but the
caller increments `qp_floor_step` immediately before calling it:

```c
enc->qp_floor_step++;
if (ENC_H264_SetQpFloor(enc, qp_floor) == H264ENC_OK)
```

so the guard is never true. `qp_orig_min`, `qp_orig_max` and `qp_orig_hdr` are assigned nowhere else
and keep the zero initialiser from the static `g_enc`. `ENC_H264_RestoreQp` then calls
`H264EncSetRateCtrl` with `qpMin = qpMax = qpHdr = 0`, which is accepted: the QP validation rejects
only values above `51`, or `qpMax < qpMin`.

The encoder is left pinned at QP 0, and the only outward sign is the log line saying quality was
restored. On one of our cameras every subsequent frame then failed with
`H264ENC_OUTPUT_BUFFER_OVERFLOW`.

**2. One success disarms the ladder permanently.**

`startup_failures` is incremented only inside the `!first_frame_done` branch, so once a frame
succeeds the counter can never advance again. `first_frame_done` is cleared only in `enc_start`, and
in the current tree no reachable runtime path calls that after boot: `video_encoder_node_start` and
`ENCODER_CMD_START_ENCODE` have no callers, and the init and deinit loops in `video_pipeline.c` are
commented out. So the escape can act at most once per boot, and cannot respond to a failure run that
begins later.

### The change

- Delete the dead snapshot and `ENC_H264_RestoreQp`. The floor is only ever raised, and `enc_start`
  re-inits the codec at the configured quality, so there is nothing to restore.
- Track the floor in force (`enc->qp_floor`) rather than a step index, which makes the QP-0 state
  unrepresentable rather than repaired.
- Drop the `!first_frame_done` gate so a run of consecutive failures is handled whenever it happens,
  not only before the first success. The threshold is unchanged at 30 consecutive failures; measured
  mean consecutive-failure run length on a healthy camera here is ~1, so this does not arm in normal
  operation.
- Clamp at `ENC_QP_MAX` and log once when the ladder is exhausted, instead of re-evaluating a
  rejected rung silently every 30 failures.
- Carry the real `H264EncStrmEncode` return code onto the escalation line. `VENC_H264_EncodeFrame`
  collapses every failure to `-1`, which makes `H264ENC_OUTPUT_BUFFER_OVERFLOW` indistinguishable
  from `H264ENC_HW_TIMEOUT` in the log. The line fires at most three times per session, so this
  cannot flood.

Net -17 lines across `Custom/Hal/enc.c` and `enc.h`.

### Testing

Built at `STEDGEAI_VARIANT=3.0` and flashed to both of our NE301 units.

On the camera that was failing, the escape fired once and held:

```
encoder failed 30 consecutive frames (enc ret -8); QP floor raised to 33
```

`-8` is `H264ENC_OUTPUT_BUFFER_OVERFLOW`. One rung was enough; rungs 2 and 3 were not needed and the
ladder stayed quiet afterwards. The camera resumed publishing at ~29.6 fps and has run clean since.

On the second camera the escape did not arm at boot: zero QP-floor lines, which is the intended
no-op on hardware that does not need it.

**A correction to how that second camera was described, and it is the clearest evidence for defect
2.** Calling it healthy was wrong. Its ladder could not fire. Its own rotated logs on the pre-fix
build, over eleven hours:

| window (pre-fix build) | `Encode failed` lines | longest adjacent run | QP-floor lines |
|---|---|---|---|
| 23:01 -> 00:12 | 218 | 20 | 0 |
| 00:12 -> 03:04 | 575 | 145 | 0 |
| 03:05 -> 05:16 | 504 | 225 | 0 |
| 05:17 -> 08:00 | 590 | 214 | 0 |
| 08:01 -> 10:40 | 582 | 204 | 0 |

Runs of 145 to 225 adjacent failure log lines against a threshold of 30, and the ladder never fired
once, which is what defect 2 predicts. These are log lines rather than confirmed consecutive
`H264EncStrmEncode` calls, which is what can be read from a deployed unit. **The caveat is that the pre-fix log lines carry `result=-1`,
because collapsing the real return code is itself one of the things this PR fixes, so we cannot
know whether those runs were overflow or timeout.** The table shows the ladder never fired under any
of them; it does not show that the gated ladder would have.

**What the gate does and does not exercise.** After the review above, the counter is gated on
`H264ENC_OUTPUT_BUFFER_OVERFLOW`. On the gated build that camera armed once on a genuine `-8` run,
raising the floor from 25 to 33 (`VENC_DEFAULT_RATE_CTRL_QP` 25 plus `ENC_STARTUP_QP_STEP` 8), then
over 7.8 h logged 1,996 failures including one run of 171 adjacent failure lines and correctly
refused to advance. The harm the review describes therefore never occurred, because the gate
prevented it; that an ungated ladder would have clamped at 51 is inference from the threshold
arithmetic, not an observation. The other camera, still on the pre-fix build, logged 2,044
failures over 7.3 h, so that rate is ordinary background behaviour on this hardware. Median bitrate
over near-nominal 600 s segments moved -1.7% on the raised-floor camera against -3.9% on the
control, so the one legitimate arming cost nothing measurable.

**Still not exercised:** rungs 2 and 3. One rung has been enough in every case observed, so the
clamp-and-log-once path at `ENC_QP_MAX` has not run on hardware.
